### PR TITLE
Add a datatable component with a simple no results message

### DIFF
--- a/integration_tests/e2e/crimeMapping/crimeBatches.page.cy.ts
+++ b/integration_tests/e2e/crimeMapping/crimeBatches.page.cy.ts
@@ -1,6 +1,8 @@
 import Page from '../../pages/page'
 import CrimeBatchesPage from '../../pages/crimeMapping/crimeBatches'
 
+const url = '/crime-mapping/crime-batches'
+
 context('Crime Mapping', () => {
   context('Crime Batches', () => {
     beforeEach(() => {
@@ -10,8 +12,15 @@ context('Crime Mapping', () => {
     })
 
     it('should display the crime batches page', () => {
-      cy.visit('/crime-mapping/crime-batches')
+      cy.visit(url)
       Page.verifyOnPage(CrimeBatchesPage)
+    })
+
+    it('should display the no result message when no search results', () => {
+      cy.visit(url)
+      const page = Page.verifyOnPage(CrimeBatchesPage)
+
+      page.dataTable.shouldNotHaveResults()
     })
   })
 })

--- a/integration_tests/pages/components/dataTableComponent.ts
+++ b/integration_tests/pages/components/dataTableComponent.ts
@@ -1,0 +1,36 @@
+import { v4 as uuidv4 } from 'uuid'
+import { PageElement } from '../page'
+
+export default class DataTableComponent {
+  private elementCacheId: string = uuidv4()
+
+  constructor() {
+    cy.get('.datatable', { log: false }).as(`${this.elementCacheId}-element`)
+  }
+
+  // PROPERTIES
+
+  get element(): PageElement {
+    return cy.get(`@${this.elementCacheId}-element`, { log: false })
+  }
+
+  get table(): PageElement {
+    return this.element.get('.govuk-table')
+  }
+
+  get noResultsMessage(): PageElement {
+    return this.element.get('[data-qa="no-results-message"]')
+  }
+
+  // HELPERS
+
+  shouldHaveResults(): void {
+    this.table.should('exist')
+    this.noResultsMessage.should('not.exist')
+  }
+
+  shouldNotHaveResults(): void {
+    this.table.should('not.exist')
+    this.noResultsMessage.should('have.text', 'There are no results.')
+  }
+}

--- a/integration_tests/pages/crimeMapping/crimeBatches.ts
+++ b/integration_tests/pages/crimeMapping/crimeBatches.ts
@@ -1,8 +1,13 @@
 import AppPage from '../appPage'
+import DataTableComponent from '../components/dataTableComponent'
 
 export default class CrimeBatchesPage extends AppPage {
   constructor() {
     super('Crime Batches')
+  }
+
+  get dataTable(): DataTableComponent {
+    return new DataTableComponent()
   }
 
   checkOnPage(): void {

--- a/server/views/components/datatable/macro.njk
+++ b/server/views/components/datatable/macro.njk
@@ -1,0 +1,3 @@
+{% macro dataTable(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/datatable/template.njk
+++ b/server/views/components/datatable/template.njk
@@ -1,0 +1,17 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+<div class="datatable govuk-grid-row govuk-!-margin-top-6">
+  <div class="govuk-grid-column-full">
+    {% if params.rows.length %}
+      {{
+        govukTable({
+          firstCellIsHeader: true,
+          head: params.columns,
+          rows: params.rows
+        })
+      }}
+    {% else %}
+      <p class="govuk-body" data-qa="no-results-message">There are no results.</p>
+    {% endif %}
+  </div>
+</div>

--- a/server/views/pages/crime-mapping/crimeBatches.njk
+++ b/server/views/pages/crime-mapping/crimeBatches.njk
@@ -1,11 +1,61 @@
 {% extends "../../partials/layout.njk" %}
+{% from "moj/components/search/macro.njk" import mojSearch %}
+{% from "../../components/datatable/macro.njk" import dataTable %}
 
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body" %}
 {% set activeLinkId = "crime-mapping" %}
 
 {% block content %}
-
   <h1>Crime Batches</h1>
 
+  {{
+    mojSearch({
+      action: "#",
+      method: "post",
+      input: {
+        id: "search",
+        name: "search"
+      },
+      label: {
+        text: "Find a crime batch",
+        classes: "govuk-!-font-weight-bold"
+      },
+      hint: {
+        text: "You can search by police force or ingestion date"
+      },
+      button: {
+        text: "Search"
+      }
+    })
+  }}
+
+  {{
+    dataTable({
+      columns: [
+        {
+          text: "Police Force"
+        },
+        {
+          text: "Batch"
+        },
+        {
+          text: "Start"
+        },
+        {
+          text: "End"
+        },
+        {
+          text: "Time (Mins)"
+        },
+        {
+          text: "Distance (Metres)"
+        },
+        {
+          text: "Matches"
+        }
+      ],
+      rows: []
+    })
+  }}
 {% endblock %}


### PR DESCRIPTION
- Adds a very simple datatable nunjucks component.
- The only tested state is the no results state the page isn't wired up to get results from the api yet.

Next steps
- Wire up the controller / service to fetch data from data (doesn't actually have to work / be correct).
- Setup cypress / wiremock to mock api responses
- Build out the datatable component with sort / pagination
- Add cypress tests for the datatable component