### PR TITLE
Enable strict mode

### DIFF
--- a/server/@types/express/environment.d.ts
+++ b/server/@types/express/environment.d.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line  import/prefer-default-export
+export declare global {
+    namespace NodeJS {
+      interface ProcessEnv {
+        NODE_ENV: 'development' | 'test' | 'production'
+        PORT?: string
+        REDIS_PORT: string
+      }
+    }
+  }

--- a/server/config.ts
+++ b/server/config.ts
@@ -41,9 +41,9 @@ const auditConfig = () => {
     queueUrl: get(
       'AUDIT_SQS_QUEUE_URL',
       'http://localhost:4566/000000000000/mainQueue',
-      auditEnabled && requiredInProduction,
+      auditEnabled ? requiredInProduction : undefined,
     ),
-    serviceName: get('AUDIT_SERVICE_NAME', 'UNASSIGNED', auditEnabled && requiredInProduction),
+    serviceName: get('AUDIT_SERVICE_NAME', 'UNASSIGNED', auditEnabled ? requiredInProduction : undefined),
     region: get('AUDIT_SQS_REGION', 'eu-west-2'),
   }
 }

--- a/server/controllers/subjectController.test.ts
+++ b/server/controllers/subjectController.test.ts
@@ -4,6 +4,7 @@ import Logger from 'bunyan'
 import SubjectService from '../services/subjectService'
 import SubjectController from './subjectController'
 import getMockSubject from '../../test/mocks/mockSubject'
+import createMockLogger from '../testutils/createMockLogger'
 
 jest.mock('../services/subjectService')
 
@@ -19,6 +20,7 @@ describe('SubjectController', () => {
   let next: NextFunction
 
   beforeEach(() => {
+    logger = createMockLogger()
     mockRestClient = new RestClient(
       'crimeMatchingApi',
       {

--- a/server/data/hmppsAuditClient.test.ts
+++ b/server/data/hmppsAuditClient.test.ts
@@ -53,7 +53,7 @@ describe('hmppsAuditClient', () => {
 
       expect(actualMessageInput.QueueUrl).toEqual('http://localhost:4566/000000000000/mainQueue')
 
-      const actualMessageBody = JSON.parse(actualMessageInput.MessageBody)
+      const actualMessageBody = JSON.parse(actualMessageInput.MessageBody || '')
       expect(actualMessageBody).toEqual(expectedSqsMessageBody)
 
       const eventTime = Date.parse(actualMessageBody.when)

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -3,10 +3,13 @@ import nock from 'nock'
 import config from '../config'
 import HmppsAuthClient from './hmppsAuthClient'
 import TokenStore from './tokenStore/redisTokenStore'
+import { RedisClient } from './redisClient'
 
 jest.mock('./tokenStore/redisTokenStore')
+jest.mock('./redisClient')
 
-const tokenStore = new TokenStore(null) as jest.Mocked<TokenStore>
+const redisClient = {} as jest.Mocked<RedisClient>
+const tokenStore = new TokenStore(redisClient) as jest.Mocked<TokenStore>
 
 const username = 'Bob'
 const token = { access_token: 'token-1', expires_in: 300 }
@@ -38,7 +41,7 @@ describe('hmppsAuthClient', () => {
     })
 
     it('should return token from HMPPS Auth with username', async () => {
-      tokenStore.getToken.mockResolvedValue(null)
+      tokenStore.getToken.mockResolvedValue('')
 
       fakeHmppsAuthApi
         .post('/oauth/token', 'grant_type=client_credentials&username=Bob')
@@ -53,7 +56,7 @@ describe('hmppsAuthClient', () => {
     })
 
     it('should return token from HMPPS Auth without username', async () => {
-      tokenStore.getToken.mockResolvedValue(null)
+      tokenStore.getToken.mockResolvedValue('')
 
       fakeHmppsAuthApi
         .post('/oauth/token', 'grant_type=client_credentials')

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -71,7 +71,7 @@ export default class RestClient {
 
       return raw ? (result as Response) : result.body
     } catch (error) {
-      const sanitisedError = sanitiseError(error)
+      const sanitisedError = sanitiseError(error as UnsanitisedError)
       logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'GET'`)
       throw sanitisedError
     }
@@ -101,7 +101,7 @@ export default class RestClient {
 
       return raw ? (result as Response) : result.body
     } catch (error) {
-      const sanitisedError = sanitiseError(error)
+      const sanitisedError = sanitiseError(error as UnsanitisedError)
       logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: '${method.toUpperCase()}'`)
       throw sanitisedError
     }
@@ -143,13 +143,13 @@ export default class RestClient {
 
       return raw ? (result as Response) : result.body
     } catch (error) {
-      const sanitisedError = sanitiseError(error)
+      const sanitisedError = sanitiseError(error as UnsanitisedError)
       logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'DELETE'`)
       throw sanitisedError
     }
   }
 
-  async stream({ path = null, headers = {} }: StreamRequest = {}): Promise<Readable> {
+  async stream({ path = undefined, headers = {} }: StreamRequest = {}): Promise<Readable> {
     logger.info(`${this.name} streaming: ${path}`)
     return new Promise((resolve, reject) => {
       superagent

--- a/server/data/tokenStore/inMemoryTokenStore.ts
+++ b/server/data/tokenStore/inMemoryTokenStore.ts
@@ -8,10 +8,14 @@ export default class InMemoryTokenStore implements TokenStore {
     return Promise.resolve()
   }
 
-  public async getToken(key: string): Promise<string> {
-    if (!this.map.has(key) || this.map.get(key).expiry.getTime() < Date.now()) {
-      return Promise.resolve(null)
+  public async getToken(key: string): Promise<string | null> {
+    const token = this.map.get(key)
+
+    if (token) {
+      if (token.expiry.getTime() > Date.now()) {
+        return Promise.resolve(token.token)
+      }
     }
-    return Promise.resolve(this.map.get(key).token)
+    return Promise.resolve(null)
   }
 }

--- a/server/data/tokenStore/redisTokenStore.ts
+++ b/server/data/tokenStore/redisTokenStore.ts
@@ -23,7 +23,7 @@ export default class RedisTokenStore implements TokenStore {
     await this.client.set(`${this.prefix}${key}`, token, { EX: durationSeconds })
   }
 
-  public async getToken(key: string): Promise<string> {
+  public async getToken(key: string): Promise<string | null> {
     await this.ensureConnected()
     return this.client.get(`${this.prefix}${key}`)
   }

--- a/server/data/tokenStore/tokenStore.ts
+++ b/server/data/tokenStore/tokenStore.ts
@@ -1,4 +1,4 @@
 export default interface TokenStore {
   setToken(key: string, token: string, durationSeconds: number): Promise<void>
-  getToken(key: string): Promise<string>
+  getToken(key: string): Promise<string | null>
 }

--- a/server/data/tokenVerification.ts
+++ b/server/data/tokenVerification.ts
@@ -29,6 +29,10 @@ const tokenVerifier: TokenVerifier = async request => {
     return true
   }
 
+  if (!user) {
+    return false
+  }
+
   logger.debug(`token request for user "${user.username}'`)
 
   const result = await getApiClientToken(user.token)

--- a/server/middleware/authorisationMiddleware.test.ts
+++ b/server/middleware/authorisationMiddleware.test.ts
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken'
 import type { Request, Response } from 'express'
 
 import authorisationMiddleware from './authorisationMiddleware'
+import createMockRequest from '../testutils/createMockRequest'
 
 function createToken(authorities: string[]) {
   const payload = {
@@ -33,6 +34,7 @@ describe('authorisationMiddleware', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
+    req = createMockRequest()
   })
 
   it('should return next when no required roles', () => {

--- a/server/middleware/setUpCurrentUser.ts
+++ b/server/middleware/setUpCurrentUser.ts
@@ -18,6 +18,10 @@ export default function setUpCurrentUser() {
         authorities?: string[]
       }
 
+      if (userId === undefined || name === undefined) {
+        throw new Error('There was a problem decoding the JWT')
+      }
+
       res.locals.user = {
         ...res.locals.user,
         userId,
@@ -27,7 +31,7 @@ export default function setUpCurrentUser() {
       }
 
       if (res.locals.user.authSource === 'nomis') {
-        res.locals.user.staffId = parseInt(userId, 10) || undefined
+        res.locals.user.staffId = parseInt(userId, 10)
       }
 
       next()

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -27,7 +27,9 @@ export default function setUpWebSecurity(): Router {
           // page by an attacker.
           connectSrc: ["'self'", 'api.os.uk'],
           imgSrc: ["'self'", 'api.os.uk', 'data: blob:'],
+          // @ts-expect-error mismatch response
           scriptSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
+          // @ts-expect-error mismatch response
           styleSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
           fontSrc: ["'self'"],
           formAction: [`'self' ${config.apis.hmppsAuth.externalUrl}`],

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -2,10 +2,19 @@ import type { Express } from 'express'
 import request from 'supertest'
 import { appWithAllRoutes, user } from './testutils/appSetup'
 import AuditService, { Page } from '../services/auditService'
+import HmppsAuditClient from '../data/hmppsAuditClient'
 
 jest.mock('../services/auditService')
+jest.mock('../data/hmppsAuditClient')
+jest.mock('../data/restClient')
 
-const auditService = new AuditService(null) as jest.Mocked<AuditService>
+const hmppsAuditClient = new HmppsAuditClient({
+  queueUrl: '',
+  enabled: true,
+  region: '',
+  serviceName: '',
+}) as jest.Mocked<HmppsAuditClient>
+const auditService = new AuditService(hmppsAuditClient) as jest.Mocked<AuditService>
 
 let app: Express
 
@@ -24,7 +33,7 @@ afterEach(() => {
 
 describe('GET /', () => {
   it('should render index page', () => {
-    auditService.logPageView.mockResolvedValue(null)
+    auditService.logPageView.mockResolvedValue()
 
     return request(app)
       .get('/')

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -9,8 +9,10 @@ import type { Services } from '../../services'
 import AuditService from '../../services/auditService'
 import { HmppsUser } from '../../interfaces/hmppsUser'
 import setUpWebSession from '../../middleware/setUpWebSession'
+import HmppsAuditClient from '../../data/hmppsAuditClient'
 
 jest.mock('../../services/auditService')
+jest.mock('../../data/hmppsAuditClient')
 
 export const user: HmppsUser = {
   name: 'FIRST LAST',
@@ -22,6 +24,13 @@ export const user: HmppsUser = {
   staffId: 1234,
   userRoles: [],
 }
+
+const hmppsAuditClient = new HmppsAuditClient({
+  queueUrl: '',
+  enabled: true,
+  region: '',
+  serviceName: '',
+}) as jest.Mocked<HmppsAuditClient>
 
 export const flashProvider = jest.fn()
 
@@ -56,7 +65,7 @@ function appSetup(services: Services, production: boolean, userSupplier: () => H
 export function appWithAllRoutes({
   production = false,
   services = {
-    auditService: new AuditService(null) as jest.Mocked<AuditService>,
+    auditService: new AuditService(hmppsAuditClient) as jest.Mocked<AuditService>,
   },
   userSupplier = () => user,
 }: {

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -14,7 +14,7 @@ export type UnsanitisedError = ResponseError
 export default function sanitise(error: UnsanitisedError): SanitisedError {
   const e = new Error() as SanitisedError
   e.message = error.message
-  e.stack = error.stack
+  e.stack = error.stack|| ''
   if (error.response) {
     e.text = error.response.text
     e.status = error.response.status

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -8,7 +8,12 @@ describe('Audit service', () => {
   let auditService: AuditService
 
   beforeEach(() => {
-    hmppsAuditClient = new HmppsAuditClient(null) as jest.Mocked<HmppsAuditClient>
+    hmppsAuditClient = new HmppsAuditClient({
+      queueUrl: '',
+      enabled: true,
+      region: '',
+      serviceName: '',
+    }) as jest.Mocked<HmppsAuditClient>
     auditService = new AuditService(hmppsAuditClient)
   })
 

--- a/server/services/mapService.ts
+++ b/server/services/mapService.ts
@@ -2,6 +2,7 @@ import superagent from 'superagent'
 
 import qs from 'qs'
 import config from '../config'
+import { HttpError } from 'http-errors'
 
 type OSMapsToken = {
   access_token: string
@@ -23,7 +24,7 @@ export default class MapService {
 
       return result.body
     } catch (e) {
-      if (e.status === 401) {
+      if ((e as HttpError).status === 401) {
         throw new Error('Failed to authenticate to OS Maps API')
       }
 

--- a/server/services/subjectService.test.ts
+++ b/server/services/subjectService.test.ts
@@ -2,6 +2,7 @@ import { RestClient } from '@ministryofjustice/hmpps-rest-client'
 import Logger from 'bunyan'
 import SubjectService from './subjectService'
 import getMockSubject from '../../test/mocks/mockSubject'
+import createMockLogger from '../testutils/createMockLogger'
 
 jest.mock('@ministryofjustice/hmpps-rest-client')
 
@@ -22,6 +23,7 @@ describe('Subject Service', () => {
   const mockSubject = getMockSubject()
 
   beforeEach(() => {
+    logger = createMockLogger()
     mockRestClient = new RestClient(
       'crimeMatchingApi',
       {

--- a/server/testutils/createMockLogger.ts
+++ b/server/testutils/createMockLogger.ts
@@ -1,0 +1,10 @@
+import bunyan from 'bunyan'
+
+const createMockLogger = () =>
+  ({
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }) as unknown as jest.Mocked<bunyan>
+
+export default createMockLogger

--- a/server/testutils/createMockRequest.ts
+++ b/server/testutils/createMockRequest.ts
@@ -1,0 +1,20 @@
+import type { Request, Response } from 'express'
+
+const createMockRequest = (
+  overrideProperties: Partial<Request> = {},
+): Request => {
+  return {
+    // @ts-expect-error stubbing session
+    session: {},
+    query: {},
+    params: {},
+    user: {
+      username: '',
+      token: '',
+      authSource: '',
+    },
+    ...overrideProperties,
+  }
+}
+
+export default createMockRequest

--- a/server/testutils/createMockResponse.ts
+++ b/server/testutils/createMockResponse.ts
@@ -1,0 +1,25 @@
+import type { Response } from 'express'
+
+const createMockResponse = (): Response => {
+  // @ts-expect-error stubbing res.render
+  return {
+    locals: {
+      user: {
+        username: 'fakeUserName',
+        token: 'fakeUserToken',
+        authSource: 'nomis',
+        userId: 'fakeId',
+        name: 'fake user',
+        displayName: 'fuser',
+        userRoles: ['fakeRole'],
+        staffId: 123,
+      },
+    },
+    redirect: jest.fn(),
+    render: jest.fn(),
+    set: jest.fn(),
+    send: jest.fn(),
+  }
+}
+
+export default createMockResponse

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -20,16 +20,17 @@ export function initialiseAppInsights(): void {
 export function buildAppInsightsClient(
   { applicationName, buildNumber }: ApplicationInfo,
   overrideName?: string,
-): TelemetryClient {
+): TelemetryClient| null {
   if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
     defaultClient.context.tags['ai.cloud.role'] = overrideName || applicationName
     defaultClient.context.tags['ai.application.ver'] = buildNumber
 
     defaultClient.addTelemetryProcessor(({ tags, data }, contextObjects) => {
-      const operationNameOverride = contextObjects.correlationContext?.customProperties?.getProperty('operationName')
+      const operationNameOverride = contextObjects?.correlationContext?.customProperties?.getProperty('operationName')
       if (operationNameOverride) {
         /*  eslint-disable no-param-reassign */
         tags['ai.operation.name'] = operationNameOverride
+        // @ts-expect-error unknown behaviour
         data.baseData.name = operationNameOverride
         /*  eslint-enable no-param-reassign */
       }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -2,7 +2,6 @@ import { convertToTitleCase, initialiseName } from './utils'
 
 describe('convert to title case', () => {
   it.each([
-    [null, null, ''],
     ['empty string', '', ''],
     ['Lower case', 'robert', 'Robert'],
     ['Upper case', 'ROBERT', 'Robert'],
@@ -18,13 +17,13 @@ describe('convert to title case', () => {
 
 describe('initialise name', () => {
   it.each([
-    [null, null, null],
+    [undefined, undefined, null],
     ['Empty string', '', null],
     ['One word', 'robert', 'r. robert'],
     ['Two words', 'Robert James', 'R. James'],
     ['Three words', 'Robert James Smith', 'R. Smith'],
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
-  ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
+  ])('%s initialiseName(%s, %s)', (_: string | undefined, a: string | undefined, expected: string | null) => {
     expect(initialiseName(a)).toEqual(expected)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,12 +6,12 @@
     "sourceMap": true,
     "noEmit": false,
     "allowJs": false,
-    "strict": false,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
     "experimentalDecorators": true,
-    "typeRoots": ["./server/@types", "./node_modules/@types"]
+    "typeRoots": ["./server/@types", "./node_modules/@types"],
+    "strict": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Strict mode is needed for Zod to work correctly. Enabling strict mode highlights some inconsistent typing in some of the template repo code. Largely copied the fixes from [CEMO#14](https://github.com/ministryofjustice/hmpps-electronic-monitoring-create-an-order/pull/14/files#diff-b5e32f68bcc433506f573cc64aae69018f0a1caa3822686806a704ac1c8e906c).

Also added some unit test helpers for setting up requests, responses, logger.