### PR TITLE
Align crime batches datatable columns to requirements

### DIFF
--- a/integration_tests/e2e/crimeMapping/crimeBatches.page.cy.ts
+++ b/integration_tests/e2e/crimeMapping/crimeBatches.page.cy.ts
@@ -51,8 +51,10 @@ context('Crime Mapping', () => {
             start: '2024-12-01T00:00:00.000Z',
             end: '2024-12-01T23:59:59.000Z',
             time: 10,
-            distance: 100,
             matches: 1,
+            ingestionDate: '2024-12-02T09:00:00.000Z',
+            caseloadMappingDate: '2024-12-01T00:00:00.000Z',
+            crimeMatchingAlgorithmVersion: 'v0.0.1',
           },
           {
             policeForce: 'Police Force 2',
@@ -60,8 +62,10 @@ context('Crime Mapping', () => {
             start: '2024-12-01T00:00:00.000Z',
             end: '2024-12-01T23:59:59.000Z',
             time: 10,
-            distance: 100,
             matches: 1,
+            ingestionDate: '2024-12-02T09:00:00.000Z',
+            caseloadMappingDate: '2024-12-01T00:00:00.000Z',
+            crimeMatchingAlgorithmVersion: 'v0.0.1',
           },
         ],
       })
@@ -83,12 +87,34 @@ context('Crime Mapping', () => {
         'Start',
         'End',
         'Time (Mins)',
-        'Distance (Metres)',
         'Matches',
+        'AC Ingestion Date',
+        'AC Caseload Mapping Date',
+        'Algorithm Version',
       ])
       page.dataTable.shouldHaveRows([
-        ['Police Force 1', '01234456789', '2024-12-01T00:00:00.000Z', '2024-12-01T23:59:59.000Z', '10', '100', '1'],
-        ['Police Force 2', '01234456789', '2024-12-01T00:00:00.000Z', '2024-12-01T23:59:59.000Z', '10', '100', '1'],
+        [
+          'Police Force 1',
+          '01234456789',
+          '2024-12-01T00:00:00.000Z',
+          '2024-12-01T23:59:59.000Z',
+          '10',
+          '1',
+          '2024-12-02T09:00:00.000Z',
+          '2024-12-01T00:00:00.000Z',
+          'v0.0.1',
+        ],
+        [
+          'Police Force 2',
+          '01234456789',
+          '2024-12-01T00:00:00.000Z',
+          '2024-12-01T23:59:59.000Z',
+          '10',
+          '1',
+          '2024-12-02T09:00:00.000Z',
+          '2024-12-01T00:00:00.000Z',
+          'v0.0.1',
+        ],
       ])
     })
   })

--- a/integration_tests/mockApis/crimeMatching/crimeBatches.ts
+++ b/integration_tests/mockApis/crimeMatching/crimeBatches.ts
@@ -60,8 +60,10 @@ type StubGetCrimeBatches200Options = {
     start: string
     end: string
     time: number
-    distance: number
     matches: number
+    ingestionDate: string
+    caseloadMappingDate: string
+    crimeMatchingAlgorithmVersion: string
   }>
 }
 

--- a/server/controllers/crimeMapping/crimeBatches.test.ts
+++ b/server/controllers/crimeMapping/crimeBatches.test.ts
@@ -98,8 +98,10 @@ describe('CrimeBatchesController', () => {
           start: '2024-12-01T00:00:00.000Z',
           end: '2024-12-01T23:59:59.000Z',
           time: 10,
-          distance: 100,
           matches: 1,
+          ingestionDate: '2024-12-09:00:00.000Z',
+          caseloadMappingDate: '2024-12-01T00:00:00.000Z',
+          crimeMatchingAlgorithmVersion: 'v0.0.1',
         },
       ])
 
@@ -123,8 +125,10 @@ describe('CrimeBatchesController', () => {
               start: '2024-12-01T00:00:00.000Z',
               end: '2024-12-01T23:59:59.000Z',
               time: 10,
-              distance: 100,
               matches: 1,
+              ingestionDate: '2024-12-09:00:00.000Z',
+              caseloadMappingDate: '2024-12-01T00:00:00.000Z',
+              crimeMatchingAlgorithmVersion: 'v0.0.1',
             },
           ],
         }),

--- a/server/schemas/crimeMapping/crimeBatches.ts
+++ b/server/schemas/crimeMapping/crimeBatches.ts
@@ -19,8 +19,10 @@ const getCrimeBatchesQueryDtoSchema = z.array(
     start: z.string(),
     end: z.string(),
     time: z.number(),
-    distance: z.number(),
     matches: z.number(),
+    ingestionDate: z.string(),
+    caseloadMappingDate: z.string(),
+    crimeMatchingAlgorithmVersion: z.string(),
   }),
 )
 

--- a/server/types/crimeMapping/crimeBatches.ts
+++ b/server/types/crimeMapping/crimeBatches.ts
@@ -4,8 +4,10 @@ type CrimeBatch = {
   start: string
   end: string
   time: number
-  distance: number
   matches: number
+  ingestionDate: string
+  caseloadMappingDate: string
+  crimeMatchingAlgorithmVersion: string
 }
 
 type GetCrimeBatchesQueryResponseDto = Array<CrimeBatch>

--- a/server/views/pages/crime-mapping/crimeBatches.njk
+++ b/server/views/pages/crime-mapping/crimeBatches.njk
@@ -28,10 +28,16 @@
           text: crimeBatch.time
         },
         {
-          text: crimeBatch.distance
+          text: crimeBatch.matches
         },
         {
-          text: crimeBatch.matches
+          text: crimeBatch.ingestionDate
+        },
+        {
+          text: crimeBatch.caseloadMappingDate
+        },
+        {
+          text: crimeBatch.crimeMatchingAlgorithmVersion
         }
       ]
     ), rows)
@@ -85,10 +91,16 @@
           text: "Time (Mins)"
         },
         {
-          text: "Distance (Metres)"
+          text: "Matches"
         },
         {
-          text: "Matches"
+          text: "AC Ingestion Date"
+        },
+        {
+          text: "AC Caseload Mapping Date"
+        },
+        {
+          text: "Algorithm Version"
         }
       ],
       rows: rows


### PR DESCRIPTION
Previous pull request created the page using the columns present in the figma prototype which differs from the columns present in the ACR-16.