### PR TITLE
Add the ability to view a subject i.e. view a subjects location data

### DIFF
--- a/assets/scss/components/_map.scss
+++ b/assets/scss/components/_map.scss
@@ -1,11 +1,12 @@
 .app-map {
-  border: 1px solid $govuk-border-colour;
-  position: relative;
-  height: 600px;
+  display: grid;
+  grid-template-columns: 1fr 350px;
+  grid-template-rows: calc(100vh - 65px - 77px);
 }
 
-.app-map__viewport {
-  height: 600px;
+.app-map__sidebar {
+  border-left: 1px solid $govuk-border-colour;
+  padding: govuk-spacing(0) govuk-spacing(3);
 }
 
 .app-map__error {

--- a/helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/files/stubs/__files/crime-matching-api-get-subjects-personid-1-200.json
+++ b/helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/files/stubs/__files/crime-matching-api-get-subjects-personid-1-200.json
@@ -1,0 +1,58 @@
+{
+  "locations": [
+    {
+        "point": { "latitude": 51.574865, "longitude": 0.060977 },
+        "confidenceCircle": 100,
+        "direction": -2.155,
+        "geolocationMechanism": 1,
+        "locationRef": 1,
+        "speed": 1,
+        "timestamp": ""
+      },
+      {
+        "point": { "latitude": 51.574153, "longitude": 0.058536 },
+        "confidenceCircle": 400,
+        "direction": -1.734,
+        "geolocationMechanism": 1,
+        "locationRef": 2,
+        "speed": 10,
+        "timestamp": ""
+      },
+      {
+        "point": { "latitude": 51.573248244162706,"longitude": 0.05111371418603764 },
+        "confidenceCircle": 600,
+        "direction": 1.234,
+        "geolocationMechanism": 1,
+        "locationRef": 3,
+        "speed": 0,
+        "timestamp": ""
+      },
+      {
+        "point": { "latitude": 51.574622, "longitude": 0.048643 },
+        "confidenceCircle": 200,
+        "direction": 0.08,
+        "geolocationMechanism": 1,
+        "locationRef": 4,
+        "speed": 2,
+        "timestamp": ""
+      },
+      {
+        "point": { "latitude": 51.57610341773559, "longitude": 0.048391168020475 },
+        "confidenceCircle": 120,
+        "direction": -1.4,
+        "geolocationMechanism": 1,
+        "locationRef": 5,
+        "speed": 5,
+        "timestamp": ""
+      },
+      {
+        "point": { "latitude": 51.576400900843375, "longitude": 0.045439341454295505 },
+        "confidenceCircle": 50,
+        "direction": -0.784,
+        "geolocationMechanism": 1,
+        "locationRef": 6,
+        "speed": 6,
+        "timestamp": ""
+      }
+  ]
+}

--- a/helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/files/stubs/mappings/crime-matching-api-get-subjects-personid-1-200.json
+++ b/helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/files/stubs/mappings/crime-matching-api-get-subjects-personid-1-200.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/crime-matching/subjects/1\\?from=&to="
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "crime-matching-api-get-subjects-personid-1-200.json",
+    "headers": {
+      "Content-Type": "application/json;charset=UTF-8",
+      "Server": "wiremock"
+    }
+  }
+}

--- a/server/controllers/locationData/subject.ts
+++ b/server/controllers/locationData/subject.ts
@@ -1,5 +1,8 @@
 import { RequestHandler } from 'express'
 import SubjectService from '../../services/locationData/subject'
+import { subjectQueryParametersSchema } from '../../schemas/locationData/subject'
+import createGeoJsonData from '../../presenters/crimeMapping'
+import config from '../../config'
 
 export default class SubjectController {
   constructor(private readonly service: SubjectService) {}
@@ -21,5 +24,22 @@ export default class SubjectController {
         res.redirect('/location-data/subjects')
       }
     }
+  }
+
+  view: RequestHandler = async (req, res) => {
+    const { token } = res.locals.user
+    const {
+      query,
+      params: { personId },
+    } = req
+    const { from, to } = subjectQueryParametersSchema.parse(query)
+    const queryResults = await this.service.getLocationData(token, personId, from, to)
+    const geoJsonData = createGeoJsonData(queryResults.locations)
+
+    res.render('pages/locationData/subject', {
+      points: JSON.stringify(geoJsonData.points),
+      lines: JSON.stringify(geoJsonData.lines),
+      tileUrl: config.maps.tileUrl,
+    })
   }
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -52,7 +52,7 @@ export default function routes({
   get('/location-data/subjects', subjectsController.view)
   post('/location-data/subjects', subjectsController.search)
 
-  get('/location-data/subject', crimeMappingController.view)
+  get('/location-data/:personId', subjectController.view)
   post('/location-data/subject', subjectController.search)
 
   return router

--- a/server/schemas/locationData/subject.ts
+++ b/server/schemas/locationData/subject.ts
@@ -8,8 +8,9 @@ const DATE_BETWEEN_ORDER = 'Date and time search window should be within Order d
 const DATE_RANGE = 'Date and time search window should not exceed 48 hours'
 const maxDateRange = 48 * 60 * 60 * 1000
 
-const subjectLocationsQueryParametersSchema = z.object({
-  queryId: z.string().optional(),
+const subjectQueryParametersSchema = z.object({
+  from: z.string().optional(),
+  to: z.string().optional(),
 })
 
 const subjectLocationsFormDataSchema = z
@@ -80,4 +81,26 @@ const createSubjectLocationsQueryDtoSchema = z.object({
   queryExecutionId: z.string(),
 })
 
-export { subjectLocationsQueryParametersSchema, subjectLocationsFormDataSchema, createSubjectLocationsQueryDtoSchema }
+const getSubjectDtoSchema = z.object({
+  locations: z.array(
+    z.object({
+      locationRef: z.number(),
+      point: z.object({
+        latitude: z.number(),
+        longitude: z.number(),
+      }),
+      confidenceCircle: z.number(),
+      speed: z.number(),
+      direction: z.number(),
+      timestamp: z.string(),
+      geolocationMechanism: z.number(),
+    }),
+  ),
+})
+
+export {
+  subjectQueryParametersSchema,
+  subjectLocationsFormDataSchema,
+  createSubjectLocationsQueryDtoSchema,
+  getSubjectDtoSchema,
+}

--- a/server/services/locationData/subject.ts
+++ b/server/services/locationData/subject.ts
@@ -1,16 +1,18 @@
 import { asUser, RestClient, SanitisedError } from '@ministryofjustice/hmpps-rest-client'
 import { ZodError } from 'zod/v4'
-import { ValidationResult, ValidationResultModel } from '../../models/ValidationResult'
 import {
   CreateSubjectLocationsQueryRequestDto,
   CreateSubjectLocationsQueryResponseDto,
+  GetSubjectDto,
 } from '../../types/locationData/subject'
 import Result from '../../types/result'
 import {
   createSubjectLocationsQueryDtoSchema,
+  getSubjectDtoSchema,
   subjectLocationsFormDataSchema,
 } from '../../schemas/locationData/subject'
 import { convertZodErrorToValidationError } from '../../utils/errors'
+import { ValidationResult, ValidationResultModel } from '../../models/ValidationResult'
 
 export default class SubjectService {
   constructor(private readonly crimeMatchingApiClient: RestClient) {}
@@ -51,5 +53,26 @@ export default class SubjectService {
       }
       throw error
     }
+  }
+
+  async getLocationData(userToken: string, personId?: string, from?: string, to?: string): Promise<GetSubjectDto> {
+    if (personId === undefined) {
+      return {
+        locations: [],
+      }
+    }
+
+    const res = await this.crimeMatchingApiClient.get(
+      {
+        path: `/subjects/${personId}`,
+        query: {
+          from,
+          to,
+        },
+      },
+      asUser(userToken),
+    )
+
+    return getSubjectDtoSchema.parse(res)
   }
 }

--- a/server/types/locationData/subject.ts
+++ b/server/types/locationData/subject.ts
@@ -1,3 +1,9 @@
+import Location from '../location'
+
+type GetSubjectDto = {
+  locations: Array<Location>
+}
+
 type CreateSubjectLocationsQueryRequestDto = {
   personId: string
   fromDate: DateAndTimeInput
@@ -17,4 +23,4 @@ type DateAndTimeInput = {
   second: string
 }
 
-export { CreateSubjectLocationsQueryRequestDto, CreateSubjectLocationsQueryResponseDto }
+export { CreateSubjectLocationsQueryRequestDto, CreateSubjectLocationsQueryResponseDto, GetSubjectDto }

--- a/server/views/components/date-time-picker/template.njk
+++ b/server/views/components/date-time-picker/template.njk
@@ -16,51 +16,51 @@
 }}
 
 <div class="govuk-date-input">
-    <div class="govuk-date-input__item">
-      <div class="govuk-form-group">
-        {{
-          govukInput({
-            label: {
-              text: "Hour",
-              classes: "govuk-label--s"
-            },
-            classes: "govuk-date-input__input govuk-input--width-2",
-            id: params.id + "-hour",
-            name: params.name + "[hour]"
-          })
-        }}
-      </div>
+  <div class="govuk-date-input__item">
+    <div class="govuk-form-group">
+      {{
+        govukInput({
+          label: {
+            text: "Hour",
+            classes: "govuk-label--s"
+          },
+          classes: "govuk-date-input__input govuk-input--width-2",
+          id: params.id + "-hour",
+          name: params.name + "[hour]"
+        })
+      }}
     </div>
+  </div>
 
-    <div class="govuk-date-input__item">
-      <div class="govuk-form-group">
-        {{
-          govukInput({
-            label: {
-              text: "Minute",
-              classes: "govuk-label--s"
-            },
-            classes: "govuk-date-input__input govuk-input--width-2",
-            id: params.id + "-minute",
-            name: params.name + "[minute]"
-          })
-        }}
-      </div>
+  <div class="govuk-date-input__item">
+    <div class="govuk-form-group">
+      {{
+        govukInput({
+          label: {
+            text: "Minute",
+            classes: "govuk-label--s"
+          },
+          classes: "govuk-date-input__input govuk-input--width-2",
+          id: params.id + "-minute",
+          name: params.name + "[minute]"
+        })
+      }}
     </div>
+  </div>
 
-    <div class="govuk-date-input__item">
-      <div class="govuk-form-group">
-        {{
-          govukInput({
-            label: {
-              text: "Second",
-              classes: "govuk-label--s"
-            },
-            classes: "govuk-date-input__input govuk-input--width-2",
-            id: params.id + "-second",
-            name: params.name + "[second]"
-          })
-        }}
-      </div>
+  <div class="govuk-date-input__item">
+    <div class="govuk-form-group">
+      {{
+        govukInput({
+          label: {
+            text: "Second",
+            classes: "govuk-label--s"
+          },
+          classes: "govuk-date-input__input govuk-input--width-2",
+          id: params.id + "-second",
+          name: params.name + "[second]"
+        })
+      }}
     </div>
+  </div>
 </div>

--- a/server/views/components/map/template.njk
+++ b/server/views/components/map/template.njk
@@ -1,41 +1,38 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
-<div class="govuk-grid-row">
-  <div
-    class="app-map"
-    data-module="app-map"
-    data-points="{{ params.geoData.points }}"
-    data-lines="{{ params.geoData.lines }}"
-    data-tile-url="{{ params.tileUrl }}"
-  >
-    <div class="govuk-grid-column-two-thirds govuk-!-static-padding-0">
-      <div id="app-map" class="app-map__viewport" data-map-viewport></div>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <h3>Enhanced Analysis</h3>
+<div
+  class="app-map"
+  data-module="app-map"
+  data-points="{{ params.geoData.points }}"
+  data-lines="{{ params.geoData.lines }}"
+  data-tile-url="{{ params.tileUrl }}"
+>
+  <div id="app-map" class="app-map__viewport" data-map-viewport></div>
+  <div class="app-map__sidebar">
+    <h3>Enhanced Analysis</h3>
+    {{
+      govukCheckboxes({
+        id: "locations",
+        name: "locations",
+        fieldset: {
+          legend: {
+            text: "Show locations",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--s"
+          }
+        },
+        items: [
+          {
+            value: "on",
+            text: "Toggled on",
+            checked: true
+          }
+        ]
+      })
+    }}
 
-      {{
-        govukCheckboxes({
-          id: "locations",
-          name: "locations",
-          fieldset: {
-            legend: {
-              text: "Show locations",
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
-          items: [
-            {
-              value: "on",
-              text: "Toggled on",
-              checked: true
-            }
-          ]
-        })
-      }}
-
-      {{ govukCheckboxes({
+    {{
+      govukCheckboxes({
         id: "confidence",
         name: "confidence",
         fieldset: {
@@ -52,9 +49,11 @@
             checked: false
           }
         ]
-      }) }}
+      })
+    }}
 
-      {{ govukCheckboxes({
+    {{
+      govukCheckboxes({
         id: "tracks",
         name: "tracks",
         fieldset: {
@@ -71,7 +70,7 @@
             checked: false
           }
         ]
-      }) }}
-    </div>
+      })
+    }}
   </div>
 </div>

--- a/server/views/pages/locationData/index.njk
+++ b/server/views/pages/locationData/index.njk
@@ -101,81 +101,81 @@
     <form action="/location-data/subject" method="post" novalidate id="subject-location-form">
       <div class="govuk-grid-column-one-third">
         <h2>Location Data</h2>
-          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-          {{
-            dateTimePicker({
-              id: "from-date",
-              name: "fromDate",
-              text: "Date and time from",
-              label: "From",
-              errors: errors.fromDate
-            })
-          }}
-
-          {{
-            dateTimePicker({
-              id: "to-date",
-              name: "toDate",
-              text: "Date and time to",
-              label: "To",
-              errors: errors.toDate
-            })
-          }}
-
-          {{
-            govukButton({
-              text: "Continue",
-              id: "continue",
-              classes: "govuk-button--secondary",
-              disabled: true
-            })
-          }}
-      </div>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
         {{
-          dataTable({
-            columns: [
-              {
-                text: ""
-              },
-              {
-                text: "NOMIS ID"
-              },
-              {
-                text: "Name"
-              },
-              {
-                text: "Date of Birth"
-              },
-              {
-                text: "Address"
-              },
-              {
-                text: "Order Start"
-              },
-              {
-                text: "Order End"
-              },
-              {
-                text: "Device ID"
-              },
-              {
-                text: "Tag Period Start"
-              },
-              {
-                text: "Tag Period End"
-              }
-            ],
-            rows: rows,
-            pagination: {
-              pageCount: pageCount,
-              currentPage: pageNumber,
-              hrefPrefix: '?queryId=' + queryId
-            }
+          dateTimePicker({
+            id: "from-date",
+            name: "fromDate",
+            text: "Date and time from",
+            label: "From",
+            errors: errors.fromDate
           })
         }}
 
-        <input type="hidden" name="orderStartDate" id="subjectOrderStartDate">
-        <input type="hidden" name="orderEndDate" id="subjectOrderEndDate">
-      </form>
+        {{
+          dateTimePicker({
+            id: "to-date",
+            name: "toDate",
+            text: "Date and time to",
+            label: "To",
+            errors: errors.toDate
+          })
+        }}
+
+        {{
+          govukButton({
+            text: "Continue",
+            id: "continue",
+            classes: "govuk-button--secondary",
+            disabled: true
+          })
+        }}
+      </div>
+      {{
+        dataTable({
+          columns: [
+            {
+              text: ""
+            },
+            {
+              text: "NOMIS ID"
+            },
+            {
+              text: "Name"
+            },
+            {
+              text: "Date of Birth"
+            },
+            {
+              text: "Address"
+            },
+            {
+              text: "Order Start"
+            },
+            {
+              text: "Order End"
+            },
+            {
+              text: "Device ID"
+            },
+            {
+              text: "Tag Period Start"
+            },
+            {
+              text: "Tag Period End"
+            }
+          ],
+          rows: rows,
+          pagination: {
+            pageCount: pageCount,
+            currentPage: pageNumber,
+            hrefPrefix: '?queryId=' + queryId
+          }
+        })
+      }}
+
+      <input type="hidden" name="orderStartDate" id="subjectOrderStartDate" />
+      <input type="hidden" name="orderEndDate" id="subjectOrderEndDate" />
+    </form>
   </div>
 {% endblock %}

--- a/server/views/pages/locationData/subject.njk
+++ b/server/views/pages/locationData/subject.njk
@@ -1,0 +1,17 @@
+{% extends "../../partials/fullWidthLayout.njk" %}
+{% from "../../components/map/macro.njk" import appMap %}
+
+{% set pageTitle = applicationName + " - Home" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+  {{
+    appMap({
+      geoData: {
+        points: points,
+        lines: lines
+      },
+      tileUrl: tileUrl
+    })
+  }}
+{% endblock %}

--- a/server/views/partials/fullWidthLayout.njk
+++ b/server/views/partials/fullWidthLayout.njk
@@ -1,0 +1,32 @@
+{% extends "govuk/template.njk" %}
+
+{% block head %}
+  <link href="{{ '/assets/css/app.css' | assetMap }}" rel="stylesheet" />
+{% endblock %}
+
+{% block pageTitle %}{{ pageTitle | default(applicationName) }}{% endblock %}
+
+{% block header %}
+  {% include "./header.njk" %}
+  {% include "./navigation.njk" %}
+{% endblock %}
+
+{% block main %}
+  <div>
+    {% block beforeContent %}{% endblock %}
+    <main
+      class="govuk-main-wrapper {%- if mainClasses %}{{ mainClasses }}{% endif %}"
+      id="main-content"
+      {%- if mainLang %}lang="{{ mainLang }}"{% endif %}
+    >
+      {% block content %}{% endblock %}
+    </main>
+  </div>
+{% endblock %}
+
+{% block bodyStart %}
+{% endblock %}
+
+{% block bodyEnd %}
+  <script type="module" src="{{ '/assets/js/app.js' | assetMap }}"></script>
+{% endblock %}


### PR DESCRIPTION
- Add the ability to view a subject.
  - In the case of this application, viewing a subject is analogous to viewing their location data. 

> N.B. This does not work with the existing search functionality. The existing search functionality will be updated to use the planned / updated pattern of querying the API/Athena. This new view can be accessed at `http://localhost:3000/location-data/1?from=&to=`.