### PR TITLE
Move the map alerts to overlay the map rather than placing them in sidebar

### DIFF
--- a/assets/js/map/tiles.js
+++ b/assets/js/map/tiles.js
@@ -22,7 +22,6 @@ const ordnanceSurveyTileLoader = token => (tile, src) => {
         tile.setState(TileState.ERROR)
       }
     })
-
     .catch(() => {
       tile.setState(TileState.ERROR)
     })

--- a/assets/scss/components/_map.scss
+++ b/assets/scss/components/_map.scss
@@ -11,11 +11,8 @@
 }
 
 .app-map__error {
-  @include govuk-font($size: 19, $weight: bold);
-  border-left: 5px solid $govuk-error-colour;
-  color: $govuk-error-colour;
-  padding: govuk-spacing(2) govuk-spacing(3);
-  margin: govuk-spacing(5);
+  position: absolute;
+  margin: 5px 60px;
 }
 
 .app-map__overlay {

--- a/integration_tests/e2e/locationData/subject.page.cy.ts
+++ b/integration_tests/e2e/locationData/subject.page.cy.ts
@@ -83,9 +83,9 @@ context('Location Data', () => {
       const page = Page.verifyOnPage(SubjectPage)
 
       page.map.shouldExist()
+      page.map.shouldNotHaveAlerts()
       page.map.sidebar.shouldExist()
       page.map.sidebar.shouldHaveControls()
-      page.map.sidebar.shouldNotHaveAlerts()
 
       // Initial state should be to show only the locations
       page.map.sidebar.showLocationToggle.shouldBeChecked()
@@ -107,9 +107,9 @@ context('Location Data', () => {
       const page = Page.verifyOnPage(SubjectPage)
 
       page.map.shouldExist()
+      page.map.shouldHaveAlert('warning', 'No GPS Data for Dates and Times Selected')
       page.map.sidebar.shouldExist()
-      page.map.sidebar.shouldNotHaveControls()
-      page.map.sidebar.shouldHaveAlert('warning', 'No GPS Data for Dates and Times Selected')
+      page.map.sidebar.shouldHaveControls()
     })
   })
 

--- a/integration_tests/pages/components/mapComponent.ts
+++ b/integration_tests/pages/components/mapComponent.ts
@@ -57,6 +57,14 @@ export default class MapComponent {
     this.sidebar.shouldExist()
   }
 
+  shouldHaveAlert(variant: string, title: string): void {
+    this.element.find(`[aria-label="${variant}: ${title}"]`).should('exist')
+  }
+
+  shouldNotHaveAlerts() {
+    return this.element.find('.moj-alert').should('have.length', 0)
+  }
+
   shouldShowOverlay(): void {
     cy.get('.ol-overlay-container').should('be.visible')
   }

--- a/integration_tests/pages/components/mapSidebarComponent.ts
+++ b/integration_tests/pages/components/mapSidebarComponent.ts
@@ -33,14 +33,6 @@ export default class MapSidebarComponent {
     this.element.should('exist')
   }
 
-  shouldHaveAlert(variant: string, title: string): void {
-    this.element.find(`[aria-label="${variant}: ${title}"]`).should('exist')
-  }
-
-  shouldNotHaveAlerts() {
-    return this.element.find('.moj-alert').should('have.length', 0)
-  }
-
   shouldHaveControls() {
     this.showLocationToggle.shouldExist()
     this.showConfidenceCirclesToggle.shouldExist()

--- a/server/controllers/locationData/subject.test.ts
+++ b/server/controllers/locationData/subject.test.ts
@@ -319,7 +319,7 @@ describe('SubjectController', () => {
           {
             dismissible: false,
             showTitleAsHeading: true,
-            text: 'Try adjusting the date range to return location data',
+            text: '',
             title: 'No GPS Data for Dates and Times Selected',
             variant: 'warning',
           },
@@ -406,6 +406,7 @@ describe('SubjectController', () => {
               timestamp: '2025-01-01T00:00:00Z',
               confidence: 10,
               point: { latitude: 123.123, longitude: 123.123 },
+              type: 'location-point',
             },
             geometry: {
               type: 'Point',
@@ -423,6 +424,7 @@ describe('SubjectController', () => {
               timestamp: '2025-01-01T00:01:00Z',
               confidence: 20,
               point: { latitude: 456.123, longitude: 456.123 },
+              type: 'location-point',
             },
             geometry: {
               type: 'Point',

--- a/server/controllers/locationData/subject.ts
+++ b/server/controllers/locationData/subject.ts
@@ -40,12 +40,7 @@ export default class SubjectController {
     const geoJsonData = createGeoJsonData(queryResults.locations)
 
     if (queryResults.locations.length === 0) {
-      alerts.push(
-        createMojAlertWarning(
-          'No GPS Data for Dates and Times Selected',
-          'Try adjusting the date range to return location data',
-        ),
-      )
+      alerts.push(createMojAlertWarning('No GPS Data for Dates and Times Selected'))
     }
 
     res.render('pages/locationData/subject', {

--- a/server/presenters/crimeMapping.ts
+++ b/server/presenters/crimeMapping.ts
@@ -26,6 +26,7 @@ type PointFeature = {
     timestamp?: string
     confidence: number
     point: Point
+    type: string
   }
   geometry: {
     type: 'Point'
@@ -50,6 +51,7 @@ const createGeoJsonData = (locations: Array<Location>): GeoJsonData => ({
       timestamp: location.timestamp,
       confidence: location.confidenceCircle,
       point: location.point,
+      type: 'location-point',
     },
     geometry: {
       type: 'Point',

--- a/server/utils/alerts.ts
+++ b/server/utils/alerts.ts
@@ -14,6 +14,6 @@ const createMojAlertInformation = (title: string, text: string) => createMojAler
 
 const createMojAlertSuccess = (title: string, text: string) => createMojAlert('success', title, text)
 
-const createMojAlertWarning = (title: string, text: string) => createMojAlert('warning', title, text)
+const createMojAlertWarning = (title: string, text: string = '') => createMojAlert('warning', title, text)
 
 export { createMojAlert, createMojAlertError, createMojAlertInformation, createMojAlertSuccess, createMojAlertWarning }

--- a/server/views/components/map/template.njk
+++ b/server/views/components/map/template.njk
@@ -12,74 +12,74 @@
 >
   <div id="app-map" class="app-map__viewport" data-map-viewport></div>
   <div class="app-map__error">
-{% for alert in params.alerts %}
-        {{ mojAlert(alert) }}
-      {% endfor %}
-    </div>
+    {% for alert in params.alerts %}
+      {{ mojAlert(alert) }}
+    {% endfor %}
+  </div>
   <div class="app-map__sidebar">
-      <h3 class="govuk-heading-m">Enhanced Analysis</h3>
-      {{
-        govukCheckboxes({
-          id: "locations",
-          name: "locations",
-          fieldset: {
-            legend: {
-              text: "Show locations",
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
-          items: [
-            {
-              value: "on",
-              text: "Toggled on",
-              checked: true
-            }
-          ]
-        })
-      }}
+    <h3 class="govuk-heading-m">Enhanced Analysis</h3>
+    {{
+      govukCheckboxes({
+        id: "locations",
+        name: "locations",
+        fieldset: {
+          legend: {
+            text: "Show locations",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--s"
+          }
+        },
+        items: [
+          {
+            value: "on",
+            text: "Toggled on",
+            checked: true
+          }
+        ]
+      })
+    }}
 
-      {{
-        govukCheckboxes({
-          id: "confidence",
-          name: "confidence",
-          fieldset: {
-            legend: {
-              text: "Show confidence circles",
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
-          items: [
-            {
-              value: "on",
-              text: "Toggled on",
-              checked: false
-            }
-          ]
-        })
-      }}
+    {{
+      govukCheckboxes({
+        id: "confidence",
+        name: "confidence",
+        fieldset: {
+          legend: {
+            text: "Show confidence circles",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--s"
+          }
+        },
+        items: [
+          {
+            value: "on",
+            text: "Toggled on",
+            checked: false
+          }
+        ]
+      })
+    }}
 
-      {{
-        govukCheckboxes({
-          id: "tracks",
-          name: "tracks",
-          fieldset: {
-            legend: {
-              text: "Show tracks",
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
-          items: [
-            {
-              value: "on",
-              text: "Toggled on",
-              checked: false
-            }
-          ]
-        })
-      }}
+    {{
+      govukCheckboxes({
+        id: "tracks",
+        name: "tracks",
+        fieldset: {
+          legend: {
+            text: "Show tracks",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--s"
+          }
+        },
+        items: [
+          {
+            value: "on",
+            text: "Toggled on",
+            checked: false
+          }
+        ]
+      })
+    }}
   </div>
   <div class="app-map__overlay">
     {% if params.showOverlay %}
@@ -87,20 +87,22 @@
          They are used as markers and replaced within assets/js files at runtime.
          Implemented this way to avoid large Template Literals in the JavaScript file. #}
       {% raw %}
-      <template id="map-overlay-template">
-        <div class="app-map__overlay-header">
-          <button type="button" class="app-map__overlay-close" aria-label="Close overlay">&times;</button>
-        </div>
-        <div class="app-map__overlay-body">
-          <div class="app-map__overlay-row"><strong>Speed:</strong><span>{{ speed }}</span></div>
-          <div class="app-map__overlay-row"><strong>Direction:</strong><span>{{ direction }}</span></div>
-          <div class="app-map__overlay-row"><strong>Geolocation Mechanism:</strong><span>{{ geolocationMechanism }}</span></div>
-          <div class="app-map__overlay-row"><strong>Recorded Date:</strong><span>{{ timestamp }}</span></div>
-          <div class="app-map__overlay-row"><strong>Confidence:</strong><span>{{ confidenceCircle }}</span></div>
-          <div class="app-map__overlay-row"><strong>Latitude:</strong><span>{{ latitude }}</span></div>
-          <div class="app-map__overlay-row"><strong>Longitude:</strong><span>{{ longitude }}</span></div>
-        </div>
-      </template>
+        <template id="map-overlay-template">
+          <div class="app-map__overlay-header">
+            <button type="button" class="app-map__overlay-close" aria-label="Close overlay">&times;</button>
+          </div>
+          <div class="app-map__overlay-body">
+            <div class="app-map__overlay-row"><strong>Speed:</strong><span>{{ speed }}</span></div>
+            <div class="app-map__overlay-row"><strong>Direction:</strong><span>{{ direction }}</span></div>
+            <div class="app-map__overlay-row">
+              <strong>Geolocation Mechanism:</strong><span>{{ geolocationMechanism }}</span>
+            </div>
+            <div class="app-map__overlay-row"><strong>Recorded Date:</strong><span>{{ timestamp }}</span></div>
+            <div class="app-map__overlay-row"><strong>Confidence:</strong><span>{{ confidenceCircle }}</span></div>
+            <div class="app-map__overlay-row"><strong>Latitude:</strong><span>{{ latitude }}</span></div>
+            <div class="app-map__overlay-row"><strong>Longitude:</strong><span>{{ longitude }}</span></div>
+          </div>
+        </template>
       {% endraw %}
     {% endif %}
   </div>

--- a/server/views/components/map/template.njk
+++ b/server/views/components/map/template.njk
@@ -11,12 +11,12 @@
   data-show-overlay="{{ params.showOverlay }}"
 >
   <div id="app-map" class="app-map__viewport" data-map-viewport></div>
-  <div class="app-map__sidebar">
-    {% if params.alerts | length > 0 %}
-      {% for alert in params.alerts %}
+  <div class="app-map__error">
+{% for alert in params.alerts %}
         {{ mojAlert(alert) }}
       {% endfor %}
-    {% else %}
+    </div>
+  <div class="app-map__sidebar">
       <h3 class="govuk-heading-m">Enhanced Analysis</h3>
       {{
         govukCheckboxes({
@@ -80,7 +80,6 @@
           ]
         })
       }}
-    {% endif %}
   </div>
   <div class="app-map__overlay">
     {% if params.showOverlay %}


### PR DESCRIPTION
Previously any alerts / errors for the map component were placed in the sidebar. This presented a problem where the user would not be able to adjust the time ranges (in the sidebar) and resolve the error. User research also revealed a requirement for the map to contain the error message so that it was obvious the map contained no location data when being used in contextual reports.

<img width="1725" height="875" alt="Screenshot 2025-07-17 at 12 50 44" src="https://github.com/user-attachments/assets/6173ac55-e945-4bea-b33c-80cf2d39bc82" />
