### PR TITLE
Replace map with new implementation

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,25 +1,12 @@
 import * as govukFrontend from 'govuk-frontend'
 import * as mojFrontend from '@ministryofjustice/frontend'
-import MapComponent from './map'
 import initSubjectSelect from './subjectSelect'
+import initialiseLocationDataView from './views/location-data'
 
 govukFrontend.initAll()
 mojFrontend.initAll()
 initSubjectSelect()
 
-const $maps = document.querySelectorAll('[data-module="app-map"]')
-
-// eslint-disable-next-line consistent-return
-function nodeListForEach(nodes, callback) {
-  if (window.NodeList.prototype.forEach) {
-    return nodes.forEach(callback)
-  }
-
-  for (let i = 0; i < nodes.length; i += 1) {
-    callback.call(window, nodes[i], i, nodes)
-  }
+if (document.querySelector('.location-data')) {
+  initialiseLocationDataView()
 }
-
-nodeListForEach($maps, $map => {
-  new MapComponent($map).init()
-})

--- a/assets/js/views/location-data/controls/layerVisibilityToggle.js
+++ b/assets/js/views/location-data/controls/layerVisibilityToggle.js
@@ -1,12 +1,18 @@
-const toggleVisibility = layer => () => {
-  layer.setVisible(!layer.getVisible())
+const toggleVisibility = (layer, overlay) => () => {
+  const visible = layer.getVisible()
+
+  if (visible && overlay) {
+    overlay.setPosition(null)
+  }
+
+  layer.setVisible(!visible)
 }
 
-const createLayerVisibilityToggle = (selector, layer) => {
+const createLayerVisibilityToggle = (selector, layer, overlay) => {
   const element = document.querySelector(selector)
 
   if (element !== null) {
-    element.onchange = toggleVisibility(layer)
+    element.onchange = toggleVisibility(layer, overlay)
   }
 }
 

--- a/assets/js/views/location-data/index.js
+++ b/assets/js/views/location-data/index.js
@@ -46,7 +46,7 @@ const initialiseLocationDataView = async () => {
   })
 
   // Add controls
-  createLayerVisibilityToggle('#locations', locationsLayer)
+  createLayerVisibilityToggle('#locations', locationsLayer, locationMetadataOverlay)
   createLayerVisibilityToggle('#tracks', tracksLayer)
   createLayerVisibilityToggle('#confidence', confidenceLayer)
 

--- a/assets/js/views/location-data/index.js
+++ b/assets/js/views/location-data/index.js
@@ -49,6 +49,20 @@ const initialiseLocationDataView = async () => {
   createLayerVisibilityToggle('#locations', locationsLayer)
   createLayerVisibilityToggle('#tracks', tracksLayer)
   createLayerVisibilityToggle('#confidence', confidenceLayer)
+
+  // Expose map to Cypress for testing
+  const testEnv = typeof window !== 'undefined' && !!window.Cypress
+
+  if (testEnv) {
+    map.on('rendercomplete', () => {
+      el.olMapForCypress = map
+      el.dispatchEvent(
+        new CustomEvent('map:render:complete', {
+          detail: { mapInstance: map },
+        }),
+      )
+    })
+  }
 }
 
 export default initialiseLocationDataView

--- a/assets/js/views/location-data/layers/tracks.js
+++ b/assets/js/views/location-data/layers/tracks.js
@@ -7,6 +7,9 @@ class TracksLayer extends LayerGroup {
     super({
       visible: false,
       layers: [new LinesLayer(lines), new ArrowsLayer(lines)],
+      properties: {
+        title: 'tracksLayer',
+      },
     })
   }
 }

--- a/integration_tests/e2e/locationData/subject.page.cy.ts
+++ b/integration_tests/e2e/locationData/subject.page.cy.ts
@@ -1,4 +1,5 @@
 import BaseLayer from 'ol/layer/Base'
+import VectorLayer from 'ol/layer/Vector'
 import SubjectPage from '../../pages/locationData/subject'
 import Page from '../../pages/page'
 
@@ -132,34 +133,26 @@ context('Location Data', () => {
 
     it('should display the map with the correct layers and features', () => {
       page.map.mapInstance.then(map => {
-        const confidenceLayerGroup = map
+        const confidenceLayer = map
           .getLayers()
-          .getArray()
-          .find((l: BaseLayer) => l.get('title') === 'Confidence')
-        const confidenceLayer = confidenceLayerGroup
-          .get('layers')
           .getArray()
           .find((l: BaseLayer) => l.get('title') === 'confidenceLayer')
-        const linesLayerGroup = map
+        const tracksLayerGroup = map
           .getLayers()
           .getArray()
-          .find((l: BaseLayer) => l.get('title') === 'Lines')
-        const arrowsLayer = linesLayerGroup
+          .find((l: BaseLayer) => l.get('title') === 'tracksLayer')
+        const arrowsLayer = tracksLayerGroup
           .get('layers')
           .getArray()
           .find((l: BaseLayer) => l.get('title') === 'arrowsLayer')
-        const linesLayer = linesLayerGroup
+        const linesLayer = tracksLayerGroup
           .get('layers')
           .getArray()
           .find((l: BaseLayer) => l.get('title') === 'linesLayer')
-        const pointsLayerGroup = map
+        const pointsLayer = map
           .getLayers()
           .getArray()
-          .find((l: BaseLayer) => l.get('title') === 'Points')
-        const pointsLayer = pointsLayerGroup
-          .get('layers')
-          .getArray()
-          .find((l: BaseLayer) => l.get('title') === 'pointsLayer')
+          .find((l: BaseLayer) => l.get('title') === 'pointsLayer') as VectorLayer
 
         page.map.shouldHaveMapLayer(confidenceLayer, 'Confidence')
         page.map.shouldHaveMapLayer(arrowsLayer, 'Arrows')
@@ -174,14 +167,11 @@ context('Location Data', () => {
       page.map.element.should('have.attr', 'data-show-overlay', 'true')
 
       page.map.mapInstance.then(map => {
-        const pointsLayerGroup = map
+        const pointsLayer = map
           .getLayers()
           .getArray()
-          .find((l: BaseLayer) => l.get('title') === 'Points')
-        const pointsLayer = pointsLayerGroup
-          .get('layers')
-          .getArray()
-          .find((l: BaseLayer) => l.get('title') === 'pointsLayer')
+          .find((l: BaseLayer) => l.get('title') === 'pointsLayer') as VectorLayer
+
         const feature = pointsLayer.getSource().getFeatures()[0]
         expect(feature.get('type')).to.equal('location-point')
 
@@ -219,15 +209,10 @@ context('Location Data', () => {
 
     it('should hide the overlay when map is clicked outside a feature', () => {
       page.map.mapInstance.then(map => {
-        const pointsLayerGroup = map
+        const pointsLayer = map
           .getLayers()
           .getArray()
-          .find((l: BaseLayer) => l.get('title') === 'Points')
-
-        const pointsLayer = pointsLayerGroup
-          .get('layers')
-          .getArray()
-          .find((l: BaseLayer) => l.get('title') === 'pointsLayer')
+          .find((l: BaseLayer) => l.get('title') === 'pointsLayer') as VectorLayer
 
         const feature = pointsLayer.getSource().getFeatures()[0]
         const coordinate = feature.getGeometry().getCoordinates()
@@ -245,15 +230,10 @@ context('Location Data', () => {
 
     it('should hide the overlay when the close button is clicked', () => {
       page.map.mapInstance.then(map => {
-        const pointsLayerGroup = map
+        const pointsLayer = map
           .getLayers()
           .getArray()
-          .find((l: BaseLayer) => l.get('title') === 'Points')
-
-        const pointsLayer = pointsLayerGroup
-          .get('layers')
-          .getArray()
-          .find((l: BaseLayer) => l.get('title') === 'pointsLayer')
+          .find((l: BaseLayer) => l.get('title') === 'pointsLayer') as VectorLayer
 
         const feature = pointsLayer.getSource().getFeatures()[0]
         const coordinate = feature.getGeometry().getCoordinates()
@@ -271,15 +251,10 @@ context('Location Data', () => {
 
     it('should hide overlay when location toggle is turned off and stay hidden when turned back on', () => {
       page.map.mapInstance.then(map => {
-        const pointsLayerGroup = map
+        const pointsLayer = map
           .getLayers()
           .getArray()
-          .find((l: BaseLayer) => l.get('title') === 'Points')
-
-        const pointsLayer = pointsLayerGroup
-          .get('layers')
-          .getArray()
-          .find((l: BaseLayer) => l.get('title') === 'pointsLayer')
+          .find((l: BaseLayer) => l.get('title') === 'pointsLayer') as VectorLayer
 
         const feature = pointsLayer.getSource().getFeatures()[0]
         const coordinate = feature.getGeometry().getCoordinates()

--- a/server/views/pages/locationData/subject.njk
+++ b/server/views/pages/locationData/subject.njk
@@ -2,7 +2,7 @@
 {% from "../../components/map/macro.njk" import appMap %}
 
 {% set pageTitle = applicationName + " - Home" %}
-{% set mainClasses = "app-container govuk-body" %}
+{% set mainClasses = "app-container govuk-body location-data" %}
 {% set activeLinkId = "location-data" %}
 
 {% block content %}


### PR DESCRIPTION
- Switch the subject view over to use the new map implementation
- Refactor the map integration tests to match the new layer structure
  - In the refactor, layer groups were replaced by layers where sensible
- Add missing functionality from new implementation to close the overlay when hiding the locations layer 