### PR TITLE
Add time and export controls to the contextual report map sidebar

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -10,4 +10,8 @@ $govuk-page-width: $moj-page-width;
 @import './components/header-bar';
 @import './components/map';
 @import './components/service-navigation';
+@import './views/location-data/subject';
 @import './local';
+
+
+

--- a/assets/scss/components/_map.scss
+++ b/assets/scss/components/_map.scss
@@ -1,13 +1,12 @@
 .app-map {
   display: grid;
-  grid-template-columns: 1fr 350px;
+  grid-template-columns: 1fr 400px;
   grid-template-rows: calc(100vh - 65px - 77px);
-  margin-top: govuk-spacing(-7);
 }
 
 .app-map__sidebar {
   border-left: 1px solid $govuk-border-colour;
-  padding: govuk-spacing(4) govuk-spacing(3);
+  overflow-y: scroll;
 }
 
 .app-map__error {

--- a/assets/scss/views/location-data/_subject.scss
+++ b/assets/scss/views/location-data/_subject.scss
@@ -1,0 +1,24 @@
+.location-data {
+    padding: 0;
+    margin: 0;
+
+    .app-map__sidebar {
+
+  .govuk-tabs {
+    margin-bottom: 0;
+  }
+
+  .govuk-tabs__list {
+    padding: 0px 10px;
+  }
+
+  .govuk-tabs__list-item {
+    border-top: none;
+  }
+
+  .govuk-tabs__panel {
+    border-left: none;
+    border-bottom: none;
+  }
+}
+}

--- a/integration_tests/e2e/locationData/subject.page.cy.ts
+++ b/integration_tests/e2e/locationData/subject.page.cy.ts
@@ -92,6 +92,7 @@ context('Location Data', () => {
       page.map.shouldExist()
       page.map.shouldNotHaveAlerts()
       page.map.sidebar.shouldExist()
+      page.map.sidebar.shouldHaveTabs()
       page.map.sidebar.shouldHaveControls()
 
       // Initial state should be to show only the locations
@@ -117,6 +118,7 @@ context('Location Data', () => {
       page.map.shouldExist()
       page.map.shouldHaveAlert('warning', 'No GPS Data for Dates and Times Selected')
       page.map.sidebar.shouldExist()
+      page.map.sidebar.shouldHaveTabs()
       page.map.sidebar.shouldHaveControls()
     })
   })
@@ -136,6 +138,8 @@ context('Location Data', () => {
 
       page = Page.verifyOnPage(SubjectPage)
       page.map.shouldExist()
+      page.map.sidebar.shouldExist()
+      page.map.sidebar.shouldHaveTabs()
     })
 
     it('should display the map with the correct layers and features', () => {
@@ -276,6 +280,7 @@ context('Location Data', () => {
           page.map.shouldShowOverlay()
 
           // Turn off location points
+          page.map.sidebar.analysisTab.click()
           page.map.sidebar.showLocationToggle.click()
           page.map.shouldNotShowOverlay()
 

--- a/integration_tests/e2e/locationData/subject.page.cy.ts
+++ b/integration_tests/e2e/locationData/subject.page.cy.ts
@@ -93,6 +93,8 @@ context('Location Data', () => {
       page.map.shouldNotHaveAlerts()
       page.map.sidebar.shouldExist()
       page.map.sidebar.shouldHaveTabs()
+      page.map.sidebar.timeTab.shouldBeActive()
+      page.map.sidebar.analysisTab.shouldNotBeActive()
       page.map.sidebar.shouldHaveControls()
 
       // Initial state should be to show only the locations
@@ -120,6 +122,8 @@ context('Location Data', () => {
       page.map.sidebar.shouldExist()
       page.map.sidebar.shouldHaveTabs()
       page.map.sidebar.shouldHaveControls()
+      page.map.sidebar.timeTab.shouldBeActive()
+      page.map.sidebar.analysisTab.shouldNotBeActive()
     })
   })
 
@@ -281,6 +285,7 @@ context('Location Data', () => {
 
           // Turn off location points
           page.map.sidebar.analysisTab.click()
+          page.map.sidebar.analysisTab.shouldBeActive()
           page.map.sidebar.showLocationToggle.click()
           page.map.shouldNotShowOverlay()
 

--- a/integration_tests/pages/components/mapSidebarComponent.ts
+++ b/integration_tests/pages/components/mapSidebarComponent.ts
@@ -15,6 +15,14 @@ export default class MapSidebarComponent {
     return cy.get(`@${this.elementCacheId}-element`, { log: false })
   }
 
+  get analysisTab(): PageElement {
+    return this.element.find('#tab_analysis')
+  }
+
+  get timeTab(): PageElement {
+    return this.element.find('#tab_time')
+  }
+
   get showLocationToggle(): FormCheckboxComponent {
     return new FormCheckboxComponent(this.element, 'Show locations')
   }
@@ -44,7 +52,8 @@ export default class MapSidebarComponent {
     this.showLocationNumberingToggle.shouldExist()
   }
 
-  shouldNotHaveControls() {
-    this.element.find('input').should('have.length', 0)
+  shouldHaveTabs() {
+    this.analysisTab.should('exist')
+    this.timeTab.should('exist')
   }
 }

--- a/integration_tests/pages/components/mapSidebarComponent.ts
+++ b/integration_tests/pages/components/mapSidebarComponent.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid'
 import { PageElement } from '../page'
 import FormCheckboxComponent from './formCheckboxComponent'
+import TabComponent from './tabComponent'
 
 export default class MapSidebarComponent {
   private elementCacheId: string = uuidv4()
@@ -15,12 +16,12 @@ export default class MapSidebarComponent {
     return cy.get(`@${this.elementCacheId}-element`, { log: false })
   }
 
-  get analysisTab(): PageElement {
-    return this.element.find('#tab_analysis')
+  get analysisTab(): TabComponent {
+    return new TabComponent('#tab_analysis')
   }
 
-  get timeTab(): PageElement {
-    return this.element.find('#tab_time')
+  get timeTab(): TabComponent {
+    return new TabComponent('#tab_time')
   }
 
   get showLocationToggle(): FormCheckboxComponent {
@@ -53,7 +54,7 @@ export default class MapSidebarComponent {
   }
 
   shouldHaveTabs() {
-    this.analysisTab.should('exist')
-    this.timeTab.should('exist')
+    this.analysisTab.shouldExist()
+    this.timeTab.shouldExist()
   }
 }

--- a/integration_tests/pages/components/tabComponent.ts
+++ b/integration_tests/pages/components/tabComponent.ts
@@ -1,0 +1,34 @@
+import { v4 as uuidv4 } from 'uuid'
+import { PageElement } from '../page'
+
+export default class TabComponent {
+  private elementCacheId: string = uuidv4()
+
+  constructor(id: string) {
+    cy.get(id, { log: false }).as(`${this.elementCacheId}-element`)
+  }
+
+  get element(): PageElement {
+    return cy.get(`@${this.elementCacheId}-element`, { log: false })
+  }
+
+  // PROPERTIES
+
+  // HELPERS
+
+  shouldBeActive() {
+    this.element.should('have.attr', 'aria-selected', 'true')
+  }
+
+  shouldExist() {
+    this.element.should('exist')
+  }
+
+  shouldNotBeActive() {
+    this.element.should('have.attr', 'aria-selected', 'false')
+  }
+
+  click() {
+    this.element.click()
+  }
+}

--- a/server/views/components/date-time-picker/template.njk
+++ b/server/views/components/date-time-picker/template.njk
@@ -6,7 +6,8 @@
     id: params.id,
     name: params.name + "[date]",
     label: {
-      text: params.text
+      text: params.text,
+      classes: "govuk-label--s"
     },
     errorMessage: params.errors,
     hint: {

--- a/server/views/components/map/template.njk
+++ b/server/views/components/map/template.njk
@@ -1,4 +1,3 @@
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "moj/components/alert/macro.njk" import mojAlert %}
 
 <div
@@ -10,6 +9,7 @@
   data-show-overlay="{{ params.showOverlay }}"
   data-show-overlay="{{ params.showOverlay }}"
 >
+  
   <div id="app-map" class="app-map__viewport" data-map-viewport></div>
   <div class="app-map__error">
     {% for alert in params.alerts %}
@@ -17,90 +17,9 @@
     {% endfor %}
   </div>
   <div class="app-map__sidebar">
-    <h3 class="govuk-heading-m">Enhanced Analysis</h3>
-    {{
-      govukCheckboxes({
-        id: "locations",
-        name: "locations",
-        fieldset: {
-          legend: {
-            text: "Show locations",
-            isPageHeading: true,
-            classes: "govuk-fieldset__legend--s"
-          }
-        },
-        items: [
-          {
-            value: "on",
-            text: "Toggled on",
-            checked: true
-          }
-        ]
-      })
-    }}
-
-    {{
-      govukCheckboxes({
-        id: "confidence",
-        name: "confidence",
-        fieldset: {
-          legend: {
-            text: "Show confidence circles",
-            isPageHeading: true,
-            classes: "govuk-fieldset__legend--s"
-          }
-        },
-        items: [
-          {
-            value: "on",
-            text: "Toggled on",
-            checked: false
-          }
-        ]
-      })
-    }}
-
-    {{
-      govukCheckboxes({
-        id: "tracks",
-        name: "tracks",
-        fieldset: {
-          legend: {
-            text: "Show tracks",
-            isPageHeading: true,
-            classes: "govuk-fieldset__legend--s"
-          }
-        },
-        items: [
-          {
-            value: "on",
-            text: "Toggled on",
-            checked: false
-          }
-        ]
-      })
-    }}
-
-    {{
-      govukCheckboxes({
-        id: "numbering",
-        name: "numbering",
-        fieldset: {
-          legend: {
-            text: "Show location numbering",
-            isPageHeading: true,
-            classes: "govuk-fieldset__legend--s"
-          }
-        },
-        items: [
-          {
-            value: "on",
-            text: "Toggled on",
-            checked: false
-          }
-        ]
-      })
-    }}
+    {% if params.sidebarHtml %}
+      {{ params.sidebarHtml | safe | trim | indent(2) }}
+    {% endif %}
   </div>
   <div class="app-map__overlay">
     {% if params.showOverlay %}

--- a/server/views/pages/locationData/subject.njk
+++ b/server/views/pages/locationData/subject.njk
@@ -1,9 +1,192 @@
 {% extends "../../partials/fullWidthLayout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "../../components/map/macro.njk" import appMap %}
+{% from "../../components/date-time-picker/macro.njk" import dateTimePicker %}
 
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body location-data" %}
 {% set activeLinkId = "location-data" %}
+
+
+{% set timeHtml %}
+  {{
+    dateTimePicker({
+      id: "from-date",
+      name: "fromDate",
+      text: "Date from",
+      errors: errors.fromDate
+    })
+  }}
+
+  {{
+    dateTimePicker({
+      id: "to-date",
+      name: "toDate",
+      text: "Date to",
+      errors: errors.toDate
+    })
+  }}
+
+  <div class="govuk-button-group">
+    {{
+      govukButton({
+        text: "Apply"
+      })
+    }}
+
+    {{
+      govukButton({
+        text: "Reset",
+        classes: "govuk-button--secondary"
+      })
+    }}
+  </div>
+
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+
+  {{
+    govukRadios({
+      name: "exportOption",
+      fieldset: {
+        legend: {
+          text: "Export trail data",
+          isPageHeading: false,
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      items: [
+        {
+          value: "condensed",
+          text: "Condensed report"
+        },
+        {
+          value: "full",
+          text: "Full report"
+        }
+      ]
+    })
+  }}
+
+  {{
+    govukButton({
+      text: "Export"
+    })
+  }}
+{% endset %}
+
+
+{% set analysisHtml %}
+  {{
+    govukCheckboxes({
+      id: "locations",
+      name: "locations",
+      fieldset: {
+        legend: {
+          text: "Show locations",
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      items: [
+        {
+          value: "on",
+          text: "Toggled on",
+          checked: true
+        }
+      ]
+    })
+  }}
+
+  {{
+    govukCheckboxes({
+      id: "confidence",
+      name: "confidence",
+      fieldset: {
+        legend: {
+          text: "Show confidence circles",
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      items: [
+        {
+          value: "on",
+          text: "Toggled on",
+          checked: false
+        }
+      ]
+    })
+  }}
+
+  {{
+    govukCheckboxes({
+      id: "tracks",
+      name: "tracks",
+      fieldset: {
+        legend: {
+          text: "Show tracks",
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      items: [
+        {
+          value: "on",
+          text: "Toggled on",
+          checked: false
+        }
+      ]
+    })
+  }}
+
+  {{
+    govukCheckboxes({
+      id: "numbering",
+      name: "numbering",
+      fieldset: {
+        legend: {
+          text: "Show location numbering",
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      items: [
+        {
+          value: "on",
+          text: "Toggled on",
+          checked: false
+        }
+      ]
+    })
+  }}
+{% endset %}
+
+
+{% set sidebarHtml %}
+  {{
+    govukTabs({
+      items: [
+        {
+          label: "Time",
+          id: "adjust-time-period",
+          panel: {
+            html: timeHtml
+          }
+        },
+        {
+          label: "Analysis",
+          id: "enhanced-analysis",
+          panel: {
+            html: analysisHtml
+          }
+        }
+      ]
+    })
+  }}
+{% endset %}
 
 {% block content %}
   {{
@@ -14,7 +197,8 @@
       },
       tileUrl: tileUrl,
       alerts: alerts,
-      showOverlay: true
+      showOverlay: true,
+      sidebarHtml: sidebarHtml
     })
   }}
 {% endblock %}

--- a/server/views/pages/locationData/subject.njk
+++ b/server/views/pages/locationData/subject.njk
@@ -10,7 +10,6 @@
 {% set mainClasses = "app-container govuk-body location-data" %}
 {% set activeLinkId = "location-data" %}
 
-
 {% set timeHtml %}
   {{
     dateTimePicker({
@@ -171,14 +170,14 @@
       items: [
         {
           label: "Time",
-          id: "adjust-time-period",
+          id: "time",
           panel: {
             html: timeHtml
           }
         },
         {
           label: "Analysis",
-          id: "enhanced-analysis",
+          id: "analysis",
           panel: {
             html: analysisHtml
           }


### PR DESCRIPTION
## Description
This pull request adds the time controls and export data controls to the contextual report map view. This is purely cosmetic, and the controls are not functional.

## Changes

- Moves sidebar definition out of the map component so that different map implementations can have different sidebars / controls
- Makes the sidebar slightly wider to accommodate the date picker.
  - When the sidebar was 350px, the date picker would extend off the right of the screen
- Make the sidebar scrollable if controls extend beyond height of the map container
- Add view specific styling for the location data screen (i.e. style the tabs in the sidebar)
- Update date picker styling to match the Figma designs