### PR TITLE
Fix - Error: Cannot fit empty extent provided as geometry

### DIFF
--- a/assets/js/views/location-data/index.ts
+++ b/assets/js/views/location-data/index.ts
@@ -43,7 +43,7 @@ const initialiseLocationDataView = async () => {
   })
 
   // Focus on geolocation data
-  if (locationSource) {
+  if (locationSource && locationSource.getFeatures().length > 0) {
     map.getView().fit(locationSource.getExtent(), {
       maxZoom: 16,
       padding: [30, 30, 30, 30],


### PR DESCRIPTION
The location data view attempts to zoom the map to the extent of the positions within the location source. When there is no location data to display on the map, an error is thrown:

```shell
Error: Cannot fit empty extent provided as geometry
```

This is because the extent is calculated to be infinite when there are no features within the location source:

```js
locationSource?.getExtent()
// [Infinity,Infinity,-Infinity,-Infinity]
```

This PR ensures that the map is only zoomed to the extent of the location source if the location source contains features.