### PR TITLE
Fix - Bug where 00/01/2025 00:00:00 was parsed as 2025-01-01T00:00:00.000Z

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -3,6 +3,7 @@ import 'applicationinsights'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
 
@@ -11,6 +12,7 @@ import logger from './logger'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
+dayjs.extend(customParseFormat)
 dayjs.extend(isSameOrAfter)
 dayjs.extend(isSameOrBefore)
 

--- a/server/controllers/locationData/subject.test.ts
+++ b/server/controllers/locationData/subject.test.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
 import { RestClient } from '@ministryofjustice/hmpps-rest-client'
@@ -15,6 +16,7 @@ import ValidationService from '../../services/locationData/validationService'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
+dayjs.extend(customParseFormat)
 dayjs.extend(isSameOrAfter)
 dayjs.extend(isSameOrBefore)
 

--- a/server/controllers/locationData/subject.ts
+++ b/server/controllers/locationData/subject.ts
@@ -6,7 +6,7 @@ import config from '../../config'
 import { createMojAlertWarning } from '../../utils/alerts'
 import { MojAlert } from '../../types/govUk/mojAlert'
 import DeviceActivationsService from '../../services/deviceActivationsService'
-import { getDateComponents, parseISODate } from '../../utils/date'
+import { getDateComponents, parseDateTimeFromISOString } from '../../utils/date'
 import { flattenErrorsToMap } from '../../utils/errors'
 import ValidationService from '../../services/locationData/validationService'
 
@@ -40,8 +40,8 @@ export default class SubjectController {
     const { token } = res.locals.user
     const { query, deviceActivation } = req
     const { from, to } = subjectQueryParametersSchema.parse(query)
-    const fromDate = parseISODate(from)
-    const toDate = parseISODate(to)
+    const fromDate = parseDateTimeFromISOString(from)
+    const toDate = parseDateTimeFromISOString(to)
     const validationResult = this.validationService.validateDeviceActivationPositionsRequest(
       deviceActivation!,
       fromDate,

--- a/server/schemas/formInput/dateTime.test.ts
+++ b/server/schemas/formInput/dateTime.test.ts
@@ -1,0 +1,119 @@
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
+import DateTimeInputModel from './dateTime'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+dayjs.extend(customParseFormat)
+dayjs.extend(isSameOrAfter)
+dayjs.extend(isSameOrBefore)
+
+describe('DateTimeInputModel', () => {
+  it('should parse a valid GMT date time', () => {
+    const result = DateTimeInputModel.safeParse({ date: '01/01/2025', hour: '0', minute: '0', second: '0' })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.toISOString()).toBe('2025-01-01T00:00:00.000Z')
+  })
+
+  it('should parse a valid BST date time', () => {
+    const result = DateTimeInputModel.safeParse({ date: '01/06/2025', hour: '10', minute: '0', second: '0' })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.toISOString()).toBe('2025-06-01T09:00:00.000Z')
+  })
+
+  it('should return an error when the date value is an empty string', () => {
+    const result = DateTimeInputModel.safeParse({
+      date: '',
+      hour: '1',
+      minute: '1',
+      second: '1',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'You must enter a valid value for date',
+        path: [],
+      },
+    ])
+  })
+
+  it('should return an error when the hour value is an empty string', () => {
+    const result = DateTimeInputModel.safeParse({
+      date: '01/01/2025',
+      hour: '',
+      minute: '1',
+      second: '1',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'You must enter a valid value for date',
+        path: [],
+      },
+    ])
+  })
+
+  it('should return an error when the minute value is an empty string', () => {
+    const result = DateTimeInputModel.safeParse({
+      date: '01/01/2025',
+      hour: '1',
+      minute: '',
+      second: '1',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'You must enter a valid value for date',
+        path: [],
+      },
+    ])
+  })
+
+  it('should return an error when the second value is an empty string', () => {
+    const result = DateTimeInputModel.safeParse({
+      date: '01/01/2025',
+      hour: '1',
+      minute: '1',
+      second: '',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'You must enter a valid value for date',
+        path: [],
+      },
+    ])
+  })
+
+  it('should return an error when the date value is not a valid date', () => {
+    const result = DateTimeInputModel.safeParse({
+      date: '00/01/2025',
+      hour: '0',
+      minute: '0',
+      second: '0',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toStrictEqual([
+      {
+        code: 'custom',
+        message: 'You must enter a valid value for date',
+        path: [],
+      },
+    ])
+  })
+})

--- a/server/schemas/formInput/dateTime.ts
+++ b/server/schemas/formInput/dateTime.ts
@@ -1,48 +1,44 @@
 import { z } from 'zod/v4'
-import dayjs from 'dayjs'
-import customParseFormat from 'dayjs/plugin/customParseFormat'
-
-dayjs.extend(customParseFormat)
+import { parseDateTimeFromComponents } from '../../utils/date'
 
 const VALID_DATE = 'You must enter a valid value for date'
 
-const DateTimeInputModel = () => {
-  return z
-    .object({
-      date: z.string(),
-      hour: z.string(),
-      minute: z.string(),
-      second: z.string(),
-    })
-    .check(ctx => {
-      if (Object.values(ctx.value).some(value => value === '' || value === undefined)) {
-        ctx.issues.push({
-          code: 'custom',
-          input: ctx.value,
-          message: VALID_DATE,
-          path: [],
-        })
-        return
-      }
+const DateTimeInputModel = z
+  .object({
+    date: z.string(),
+    hour: z.string(),
+    minute: z.string(),
+    second: z.string(),
+  })
+  .check(ctx => {
+    if (Object.values(ctx.value).some(value => value === '' || value === undefined)) {
+      ctx.issues.push({
+        code: 'custom',
+        input: ctx.value,
+        message: VALID_DATE,
+        path: [],
+      })
+      return
+    }
 
-      const formattedDateTime = formatDate(ctx.value.date, ctx.value.hour, ctx.value.minute, ctx.value.second)
+    const formattedDateTime = parseDateTimeFromComponents(
+      ctx.value.date,
+      ctx.value.hour,
+      ctx.value.minute,
+      ctx.value.second,
+    )
 
-      if (!formattedDateTime.isValid()) {
-        ctx.issues.push({
-          code: 'custom',
-          input: ctx.value,
-          message: VALID_DATE,
-          path: [],
-        })
-      }
-    })
-    .transform(value => {
-      return formatDate(value.date, value.hour, value.minute, value.second)
-    })
-}
-
-function formatDate(date: string, hour: string, minute: string, second: string) {
-  return dayjs.tz(`${date} ${hour}:${minute}:${second}`, 'D/M/YYYY H:m:s', 'Europe/London')
-}
+    if (!formattedDateTime.isValid()) {
+      ctx.issues.push({
+        code: 'custom',
+        input: ctx.value,
+        message: VALID_DATE,
+        path: [],
+      })
+    }
+  })
+  .transform(value => {
+    return parseDateTimeFromComponents(value.date, value.hour, value.minute, value.second)
+  })
 
 export default DateTimeInputModel

--- a/server/schemas/locationData/subject.ts
+++ b/server/schemas/locationData/subject.ts
@@ -16,8 +16,8 @@ const subjectQueryParametersSchema = z.object({
 const subjectLocationsFormDataSchema = z
   .object({
     personId: z.string().min(1, VALID_PERSON),
-    fromDate: DateTimeInputModel(),
-    toDate: DateTimeInputModel(),
+    fromDate: DateTimeInputModel,
+    toDate: DateTimeInputModel,
     orderStartDate: z.string(),
     orderEndDate: z.string().nullable(),
   })

--- a/server/services/deviceActivationsService.ts
+++ b/server/services/deviceActivationsService.ts
@@ -1,6 +1,6 @@
 import { asUser, RestClient } from '@ministryofjustice/hmpps-rest-client'
 import dayjs, { Dayjs } from 'dayjs'
-import { parseISODate } from '../utils/date'
+import { parseDateTimeFromISOString } from '../utils/date'
 import { Location } from '../types/location'
 import { getDeviceActivationDtoSchema, getDeviceActivationPositionsDtoSchema } from '../schemas/dtos/deviceActivation'
 import DeviceActivation from '../types/entities/deviceActivation'
@@ -40,9 +40,11 @@ class DeviceActivationsService {
   }
 
   isDateRangeWithinDeviceActivation(deviceActivation: DeviceActivation, fromDate: Dayjs, toDate: Dayjs): boolean {
-    const deviceActivationDate = parseISODate(deviceActivation.deviceActivationDate)
+    const deviceActivationDate = parseDateTimeFromISOString(deviceActivation.deviceActivationDate)
     const deviceDeactivationDate =
-      deviceActivation.deviceDeactivationDate === null ? dayjs() : parseISODate(deviceActivation.deviceDeactivationDate)
+      deviceActivation.deviceDeactivationDate === null
+        ? dayjs()
+        : parseDateTimeFromISOString(deviceActivation.deviceDeactivationDate)
 
     return (
       fromDate.isSameOrAfter(deviceActivationDate) &&

--- a/server/utils/date.ts
+++ b/server/utils/date.ts
@@ -1,6 +1,19 @@
 import dayjs, { Dayjs } from 'dayjs'
 
-const parseISODate = (dateString: string) => {
+const parseDateTimeFromComponents = (date: string, hour: string, minute: string, second: string) => {
+  const dateTimeString = `${date} ${hour}:${minute}:${second}`
+  const formats = ['D/M/YYYY H:m:s', 'DD/MM/YYYY H:m:s']
+
+  const validationDate = dayjs(dateTimeString, formats, true)
+
+  if (!validationDate.isValid()) {
+    return dayjs(null)
+  }
+
+  return dayjs.tz(dateTimeString, 'D/M/YYYY H:m:s', 'Europe/London')
+}
+
+const parseDateTimeFromISOString = (dateString: string) => {
   return dayjs(dateString, ['YYYY-MM-DDTHH:mm:ss[Z]', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'], true)
 }
 
@@ -22,4 +35,4 @@ const getDateComponents = (date: Dayjs) => {
   }
 }
 
-export { getDateComponents, parseISODate }
+export { parseDateTimeFromComponents, parseDateTimeFromISOString, getDateComponents }


### PR DESCRIPTION
When testing the filtering of device activation positions by date range, I noticed that invalid dates were being parsed as valid dates in some circumstances.

When entering an invalid date with components
- date: 00/01/2025
- hour: 0
- minute: 0
- second: 0

the date would be parsed as 2025-01-01T00:00:00.000Z, i.e. the invalid day component 00 was being coerced to 01 rather than generating a validation error.

This pull requests updates the DateTimeInputModel to ensure this can't happen and adds a series of additional test cases (e.g. GMT & BST dates).

Also moves date utils to a common location.

> N.B. When testing date times, its important to remember that our dev workstations are probably using `Europe/London` timezone and GitHub Actions appears to use `UTC`. This could cause mismatches in test outputs as parsing dates using `dayjs(...)` uses the system timezone for timezone ambiguous strings. You can test that tests in GitHub Actions will pass using `TZ=UTC npm run test`