### PR TITLE
Ensure selected row is retained when an invalid date search occurs

### DIFF
--- a/assets/js/utils/utils.ts
+++ b/assets/js/utils/utils.ts
@@ -8,11 +8,22 @@
  * @returns A formatted string like "42 km/h", or the fallback value
  */
 
-export default function queryElement<T extends Element>(
+type Constructor<T> = {
+  new (): T
+}
+
+const isNodeListOfElement = <T extends Element>(
+  elements: NodeListOf<Element>,
+  expectedConstructor: Constructor<T>,
+): elements is NodeListOf<T> => {
+  return [...elements.values()].every(element => element instanceof expectedConstructor)
+}
+
+export const queryElement = <T extends Element>(
   parent: Document | Element,
   selector: string,
-  expectedConstructor?: { new (): T },
-): T {
+  expectedConstructor?: Constructor<T>,
+): T => {
   const el = parent.querySelector(selector)
 
   if (!el) {
@@ -24,4 +35,18 @@ export default function queryElement<T extends Element>(
   }
 
   return el as T
+}
+
+export const queryElementAll = <T extends Element>(
+  parent: Document | Element,
+  selector: string,
+  expectedConstructor: Constructor<T>,
+): NodeListOf<T> => {
+  const elements = parent.querySelectorAll(selector)
+
+  if (expectedConstructor && isNodeListOfElement(elements, expectedConstructor)) {
+    return elements
+  }
+
+  throw new Error(`Elements matched by "${selector}" are not instances of ${expectedConstructor.name}.`)
 }

--- a/assets/js/views/location-data-device-activation-search/index.ts
+++ b/assets/js/views/location-data-device-activation-search/index.ts
@@ -1,15 +1,11 @@
 import initialiseDateFilterForm from '../../forms/date-filter-form'
+import { queryElement, queryElementAll } from '../../utils/utils'
 
-const querySelectorAllHtmlElement = (selector: string) => {
-  return Array.from(document.querySelectorAll(selector)).filter(node => node instanceof HTMLElement)
-}
-
-const handleRadioChange = (radio: HTMLElement) => {
+const handleRadioChange = (radio: HTMLElement, form: HTMLFormElement, continueButton: HTMLButtonElement) => {
   const deviceActivationId = radio.getAttribute('value')
-  const form = document.getElementById('dateFilterForm')
-  const continueButton = document.getElementById('continue') as HTMLButtonElement
 
   if (continueButton) {
+    // eslint-disable-next-line no-param-reassign
     continueButton.disabled = false
   }
 
@@ -19,10 +15,17 @@ const handleRadioChange = (radio: HTMLElement) => {
 }
 
 const initialiseLocationDataDeviceActivationSearchView = () => {
-  const radios = querySelectorAllHtmlElement('input[type="radio"][name="deviceActivationId"]')
+  const form = queryElement(document, '#dateFilterForm', HTMLFormElement)
+  const radios = queryElementAll(document, 'input[type="radio"][name="deviceActivationId"]', HTMLInputElement)
+  const continueButton = queryElement(document, '#continue', HTMLButtonElement)
 
   radios.forEach(radio => {
-    radio.addEventListener('change', () => handleRadioChange(radio))
+    radio.addEventListener('change', () => handleRadioChange(radio, form, continueButton))
+
+    // Form loaded with radio checked
+    if (radio.checked) {
+      handleRadioChange(radio, form, continueButton)
+    }
   })
 
   initialiseDateFilterForm()

--- a/assets/js/views/location-data/index.ts
+++ b/assets/js/views/location-data/index.ts
@@ -5,7 +5,7 @@ import TracksLayer from './layers/tracks'
 import ConfidenceLayer from './layers/confidence'
 import NumberingLayer from './layers/numbering'
 import createLayerVisibilityToggle from './controls/layerVisibilityToggle'
-import queryElement from '../../utils/utils'
+import { queryElement } from '../../utils/utils'
 import initialiseDateFilterForm from '../../forms/date-filter-form'
 
 const initialiseLocationDataView = async () => {

--- a/integration_tests/e2e/locationData/subject-locations.page.error.cy.ts
+++ b/integration_tests/e2e/locationData/subject-locations.page.error.cy.ts
@@ -51,9 +51,12 @@ context('Location Data', () => {
       page = Page.verifyOnPage(SubjectsPage)
       page.dataTable.shouldHaveResults()
 
-      page.locationsForm.fillInWith({ fromDate: undefined, toDate: undefined })
       page.dataTable.selectRow('1')
+      page.locationsForm.fillInWith({ fromDate: undefined, toDate: undefined })
       page.locationsForm.continueButton.click()
+
+      page = Page.verifyOnPage(SubjectsPage)
+      page.dataTable.shouldHaveSelectedRow('1')
       page.locationsForm.fromDateField.shouldHaveValidationMessage('You must enter a valid value for date')
       page.locationsForm.toDateField.shouldHaveValidationMessage('You must enter a valid value for date')
     })
@@ -116,6 +119,9 @@ context('Location Data', () => {
       page.locationsForm.fillInWith({ fromDate, toDate })
       page.dataTable.selectRow('1')
       page.locationsForm.continueButton.click()
+
+      page = Page.verifyOnPage(SubjectsPage)
+      page.dataTable.shouldHaveSelectedRow('1')
       page.locationsForm.fromDateField.shouldHaveValidationMessage(
         'Date and time search window should be within device activation date range',
       )
@@ -167,6 +173,9 @@ context('Location Data', () => {
       page.locationsForm.fillInWith({ fromDate, toDate })
       page.dataTable.selectRow('1')
       page.locationsForm.continueButton.click()
+
+      page = Page.verifyOnPage(SubjectsPage)
+      page.dataTable.shouldHaveSelectedRow('1')
       page.locationsForm.fromDateField.shouldHaveValidationMessage(
         'Date and time search window should not exceed 48 hours',
       )
@@ -218,6 +227,9 @@ context('Location Data', () => {
       page.locationsForm.fillInWith({ fromDate, toDate })
       page.dataTable.selectRow('1')
       page.locationsForm.continueButton.click()
+
+      page = Page.verifyOnPage(SubjectsPage)
+      page.dataTable.shouldHaveSelectedRow('1')
       page.locationsForm.toDateField.shouldHaveValidationMessage('To date must be after From date')
     })
   })

--- a/integration_tests/pages/components/dataTableComponent.ts
+++ b/integration_tests/pages/components/dataTableComponent.ts
@@ -73,6 +73,10 @@ export default class DataTableComponent {
     this.pagination.shouldNotExist()
   }
 
+  shouldHaveSelectedRow(id: string): void {
+    cy.get(`input[type=radio][value="${id}"]`).should('be.checked')
+  }
+
   selectRow(id: string): void {
     cy.get(`input[type=radio][value="${id}"]`).check()
   }

--- a/server/controllers/locationData/subject.ts
+++ b/server/controllers/locationData/subject.ts
@@ -36,12 +36,18 @@ export default class SubjectController {
         const params = `from=${formData.data.fromDate}&to=${formData.data.toDate}`
         res.redirect(`/location-data/device-activations/${deviceActivation.deviceActivationId}?${params.toString()}`)
       } else {
-        req.session.formData = req.body
+        req.session.formData = {
+          ...req.body,
+          deviceActivationId: req.params.deviceActivationId,
+        }
         req.session.validationErrors = validationResult.errors
         res.redirect(req.body.origin)
       }
     } else {
-      req.session.formData = req.body
+      req.session.formData = {
+        ...req.body,
+        deviceActivationId: req.params.deviceActivationId,
+      }
       req.session.validationErrors = convertZodErrorToValidationError(formData.error)
       res.redirect(req.body.origin)
     }

--- a/server/views/pages/locationData/index.njk
+++ b/server/views/pages/locationData/index.njk
@@ -1,6 +1,7 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "../../components/datatable/macro.njk" import dataTable %}
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "../../components/date-time-picker/macro.njk" import dateTimePicker %}
@@ -15,12 +16,13 @@
 
 {% for person in persons %}
   {% for deviceActivation in person.deviceActivations %}
+    {% set selected = ' checked' if formData.deviceActivationId == deviceActivation.deviceActivationId else '' %}
     {%
       set rows = (rows.push(
         [
           {
             html: '<div class="govuk-radios__item govuk-radios--small">
-                    <input type="radio" class="govuk-radios__input" name="deviceActivationId" id="' + deviceActivation.deviceActivationId + '" value="' + deviceActivation.deviceActivationId + '" autocomplete="off">
+                    <input type="radio" class="govuk-radios__input" name="deviceActivationId" id="' + deviceActivation.deviceActivationId + '" value="' + deviceActivation.deviceActivationId + '" autocomplete="off"' + selected +'>
                     <label class="govuk-label govuk-radios__label" for="' + deviceActivation.deviceActivationId + '">
                     </label>
                   </div>'


### PR DESCRIPTION
When a bad date search was submitted on the device wearer / device activation search screen, the selected row didn't remain selected when the page reloaded.