### PR TITLE
Disable form buttons on reset

### DIFF
--- a/assets/js/forms/date-filter-form/index.ts
+++ b/assets/js/forms/date-filter-form/index.ts
@@ -14,6 +14,11 @@ const initialiseDateFilterForm = () => {
         resetButton.disabled = false
       })
     })
+
+    form.addEventListener('reset', () => {
+      continueButton.disabled = true
+      resetButton.disabled = true
+    })
   }
 }
 

--- a/integration_tests/e2e/locationData/subject-locations.page.cy.ts
+++ b/integration_tests/e2e/locationData/subject-locations.page.cy.ts
@@ -144,6 +144,8 @@ context('Location Data', () => {
         minute: '',
         second: '',
       })
+      page.locationsForm.continueButton.should('be.disabled')
+      page.locationsForm.resetButton.should('be.disabled')
     })
   })
 })

--- a/integration_tests/e2e/locationData/subject.page.cy.ts
+++ b/integration_tests/e2e/locationData/subject.page.cy.ts
@@ -170,6 +170,8 @@ context('Location Data', () => {
         second: '03',
       })
       page.map.sidebar.form.toDateField.shouldHaveValue({ date: '02/01/2025', hour: '02', minute: '04', second: '50' })
+      page.map.sidebar.form.continueButton.should('be.disabled')
+      page.map.sidebar.form.resetButton.should('be.disabled')
     })
   })
 


### PR DESCRIPTION
When the form is reset, set the buttons back to their original disabled state