### PR TITLE
Align service navigation in centre

### DIFF
--- a/assets/scss/components/_service-navigation.scss
+++ b/assets/scss/components/_service-navigation.scss
@@ -1,3 +1,3 @@
-.govuk-service-navigation__container {
+.govuk-service-navigation__list {
     justify-content: center;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "dayjs": "^1.11.13",
         "express": "^4.21.2",
         "express-session": "^1.18.1",
-        "govuk-frontend": "^5.9.0",
+        "govuk-frontend": "^5.11.0",
         "helmet": "^8.0.0",
         "hmpps-open-layers-map": "0.5.27",
         "http-errors": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "dayjs": "^1.11.13",
     "express": "^4.21.2",
     "express-session": "^1.18.1",
-    "govuk-frontend": "^5.9.0",
+    "govuk-frontend": "^5.11.0",
     "helmet": "^8.0.0",
     "hmpps-open-layers-map": "0.5.27",
     "http-errors": "^2.0.0",


### PR DESCRIPTION
#57 pulled in a more up to date version of [govuk-frontend](https://github.com/alphagov/govuk-frontend) which included this [change](https://github.com/alphagov/govuk-frontend/commit/9d2e14f571a9500b3311be87a6d17a8b0fca9423) which  caused the service navigation to change from being horizontally center aligned to left aligned.

This change updates the service navigation to ensure it is still centrally aligned.

