### PR TITLE
Generate more granular error messages when dates fall outside of a device activation

### DIFF
--- a/integration_tests/e2e/locationData/subject.page.error.cy.ts
+++ b/integration_tests/e2e/locationData/subject.page.error.cy.ts
@@ -103,7 +103,50 @@ context('Location Data', () => {
       page.map.sidebar.form.toDateField.shouldHaveValue({ date: '05/01/2025', hour: '00', minute: '00', second: '00' })
     })
 
-    it('should display validation errors if date period in url exceeds device activation period', () => {
+    it('should display validation errors if from date in url is before device activation', () => {
+      const from = '2024-12-01T00:00:00.000Z'
+      const to = '2024-12-02T00:00:00.000Z'
+      cy.stubGetDeviceActivation({
+        deviceActivationId: '1',
+        status: 200,
+        response: {
+          data: {
+            deviceActivationId: 1,
+            deviceId: 123456789,
+            deviceName: '123456789',
+            personId: 123456789,
+            deviceActivationDate: '2025-01-01T00:00:00.000Z',
+            deviceDeactivationDate: '2025-01-02T00:00:00.000Z',
+            orderStart: '2024-12-01T00:00:00.000Z',
+            orderEnd: '2024-12-31T00:00:00.000Z',
+          },
+        },
+      })
+      cy.visit(`${url}?from=${from}&to=${to}`)
+
+      const page = Page.verifyOnPage(SubjectPage)
+
+      page.map.shouldExist()
+      page.map.shouldNotHaveAlerts()
+      page.map.sidebar.shouldExist()
+      page.map.sidebar.shouldHaveTabs()
+      page.map.sidebar.timeTab.shouldBeActive()
+      page.map.sidebar.analysisTab.shouldNotBeActive()
+      page.map.sidebar.shouldHaveControls()
+
+      page.map.sidebar.form.checkHasForm()
+      page.map.sidebar.form.fromDateField.shouldHaveValue({
+        date: '01/12/2024',
+        hour: '00',
+        minute: '00',
+        second: '00',
+      })
+      page.map.sidebar.form.fromDateField.shouldHaveValidationMessage('Update date to inside tag period')
+      page.map.sidebar.form.toDateField.shouldNotHaveValidationMessage()
+      page.map.sidebar.form.toDateField.shouldHaveValue({ date: '02/12/2024', hour: '00', minute: '00', second: '00' })
+    })
+
+    it('should display validation errors if to date in url is after device activation', () => {
       const from = '2025-02-01T00:00:00.000Z'
       const to = '2025-02-02T00:00:00.000Z'
       cy.stubGetDeviceActivation({
@@ -141,11 +184,9 @@ context('Location Data', () => {
         minute: '00',
         second: '00',
       })
-      page.map.sidebar.form.fromDateField.shouldHaveValidationMessage(
-        'Date and time search window should be within device activation date range',
-      )
-      page.map.sidebar.form.toDateField.shouldNotHaveValidationMessage()
+      page.map.sidebar.form.fromDateField.shouldNotHaveValidationMessage()
       page.map.sidebar.form.toDateField.shouldHaveValue({ date: '02/02/2025', hour: '00', minute: '00', second: '00' })
+      page.map.sidebar.form.toDateField.shouldHaveValidationMessage('Update date to inside tag period')
     })
   })
 })

--- a/server/services/deviceActivationsService.ts
+++ b/server/services/deviceActivationsService.ts
@@ -1,6 +1,5 @@
 import { asUser, RestClient } from '@ministryofjustice/hmpps-rest-client'
-import dayjs, { Dayjs } from 'dayjs'
-import { parseDateTimeFromISOString } from '../utils/date'
+import { Dayjs } from 'dayjs'
 import { Location } from '../types/location'
 import { getDeviceActivationDtoSchema, getDeviceActivationPositionsDtoSchema } from '../schemas/dtos/deviceActivation'
 import DeviceActivation from '../types/entities/deviceActivation'
@@ -37,21 +36,6 @@ class DeviceActivationsService {
     )
 
     return getDeviceActivationPositionsDtoSchema.parse(response).data
-  }
-
-  isDateRangeWithinDeviceActivation(deviceActivation: DeviceActivation, fromDate: Dayjs, toDate: Dayjs): boolean {
-    const deviceActivationDate = parseDateTimeFromISOString(deviceActivation.deviceActivationDate)
-    const deviceDeactivationDate =
-      deviceActivation.deviceDeactivationDate === null
-        ? dayjs()
-        : parseDateTimeFromISOString(deviceActivation.deviceDeactivationDate)
-
-    return (
-      fromDate.isSameOrAfter(deviceActivationDate) &&
-      toDate.isSameOrBefore(deviceDeactivationDate) &&
-      fromDate.isSameOrAfter(deviceActivationDate) &&
-      toDate.isSameOrBefore(deviceDeactivationDate)
-    )
   }
 }
 


### PR DESCRIPTION
The latest figma designs and requirements in ACR-56 specify the following requirement:

```text
If the FROM Date/Time input by the user is before the 
Tag Start date - the system will alert the user that the 
FROM Date/Time input is prior the Tag Start date.
```

```text
If the TO Date/Time input by the user is after the
Tag End date - the system will alert the user that the
TO Date/Time input is after the Tag End date.
```

The error message in the Figma design is
<img width="304" height="613" alt="Screenshot 2025-09-08 at 17 07 58" src="https://github.com/user-attachments/assets/c8c94267-e943-4c31-854b-2fb800dfcb4a" />

Up to now, we had a simple check to validate the whole date range at once which didn't allow for the granularity of error messages that the requirements specify.

```js
 fromDate.isSameOrAfter(deviceActivationDate) &&
 toDate.isSameOrBefore(deviceDeactivationDate) &&
 fromDate.isSameOrAfter(deviceActivationDate) &&
 toDate.isSameOrBefore(deviceDeactivationDate)
```

I've opted to only check that `fromDate` is after the `deviceActivationDate` and the `toDate` is before the `deviceDeactivationDate`. We don't need to also check that the `fromDate` is before the `deviceDeactivationDate` and the `toDate` is after the `deviceActivationDate` because we check the `toDate` is after the `fromDate`.