### PR TITLE
Integrate with API

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/files/stubs/mappings/crime-matching-api-get-device-activation-positions-id-1-200.json
+++ b/helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/files/stubs/mappings/crime-matching-api-get-device-activation-positions-id-1-200.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPattern": "/crime-matching/device-activations/1/positions\\?from=\\S+&to=\\S+"
+    "urlPattern": "/crime-matching/device-activations/1/positions\\?from=\\S+&to=\\S+&geolocationMechanism=GPS"
   },
   "response": {
     "status": 200,

--- a/helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/files/stubs/mappings/crime-matching-api-get-device-activation-positions-id-2-200.json
+++ b/helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/files/stubs/mappings/crime-matching-api-get-device-activation-positions-id-2-200.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPattern": "/crime-matching/device-activations/2/positions\\?from=\\S+&to=\\S+"
+    "urlPattern": "/crime-matching/device-activations/2/positions\\?from=\\S+&to=\\S+&geolocationMechanism=GPS"
   },
   "response": {
     "status": 200,

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,9 +13,9 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: "false"
-    EM_CRIME_MATCHING_API_URL: "http://hmpps-electronic-monitoring-crime-matching-api-stubs/crime-matching"
+    EM_CRIME_MATCHING_API_URL: "https://electronic-monitoring-crime-matching-api-dev.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   alertSeverity: na
 
-deploy_stubs: true
+deploy_stubs: false

--- a/integration_tests/e2e/locationData/subject.export.cy.ts
+++ b/integration_tests/e2e/locationData/subject.export.cy.ts
@@ -21,7 +21,7 @@ context('Location Data', () => {
       cy.stubGetDeviceActivationPositions({
         status: 200,
         deviceActivationId,
-        query: 'from=\\S+&to=\\S+',
+        query: 'from=\\S+&to=\\S+&geolocationMechanism=GPS',
         response: sampleLocations,
       })
       cy.stubGetPerson()

--- a/integration_tests/e2e/locationData/subject.page.cy.ts
+++ b/integration_tests/e2e/locationData/subject.page.cy.ts
@@ -4,7 +4,7 @@ import Page from '../../pages/page'
 import sampleLocations from './fixtures/sample-locations'
 
 const deviceActivationId = '1'
-const query = 'from=2025-01-01T01:20:03.000Z&to=2025-01-02T02:04:50.000Z'
+const query = 'from=2025-01-01T01:20:03.000Z&to=2025-01-02T02:04:50.000Z&geolocationMechanism=GPS'
 const url = `/location-data/device-activations/${deviceActivationId}?${query}`
 
 context('Location Data', () => {
@@ -93,7 +93,7 @@ context('Location Data', () => {
       cy.stubGetDeviceActivationPositions({
         status: 200,
         deviceActivationId,
-        query: 'from=\\S+&to=\\S+',
+        query: 'from=\\S+&to=\\S+&geolocationMechanism=GPS',
         response: sampleLocations,
       })
 

--- a/integration_tests/e2e/locationData/subject.submission.cy.ts
+++ b/integration_tests/e2e/locationData/subject.submission.cy.ts
@@ -19,7 +19,7 @@ context('Location Data', () => {
       cy.stubGetDeviceActivationPositions({
         status: 200,
         deviceActivationId,
-        query: 'from=\\S+&to=\\S+',
+        query: 'from=\\S+&to=\\S+&geolocationMechanism=GPS',
         response: sampleLocations,
       })
 
@@ -66,7 +66,7 @@ context('Location Data', () => {
       cy.stubGetDeviceActivationPositions({
         status: 200,
         deviceActivationId,
-        query: 'from=\\S+&to=\\S+',
+        query: 'from=\\S+&to=\\S+&geolocationMechanism=GPS',
         response: sampleLocations,
       })
 
@@ -118,7 +118,7 @@ context('Location Data', () => {
       cy.stubGetDeviceActivationPositions({
         status: 200,
         deviceActivationId,
-        query: 'from=\\S+&to=\\S+',
+        query: 'from=\\S+&to=\\S+&geolocationMechanism=GPS',
         response: sampleLocations,
       })
 
@@ -170,7 +170,7 @@ context('Location Data', () => {
       cy.stubGetDeviceActivationPositions({
         status: 200,
         deviceActivationId,
-        query: 'from=\\S+&to=\\S+',
+        query: 'from=\\S+&to=\\S+&geolocationMechanism=GPS',
         response: sampleLocations,
       })
 
@@ -239,7 +239,7 @@ context('Location Data', () => {
       cy.stubGetDeviceActivationPositions({
         status: 200,
         deviceActivationId,
-        query: 'from=\\S+&to=\\S+',
+        query: 'from=\\S+&to=\\S+&geolocationMechanism=GPS',
         response: sampleLocations,
       })
 
@@ -306,7 +306,7 @@ context('Location Data', () => {
       cy.stubGetDeviceActivationPositions({
         status: 200,
         deviceActivationId,
-        query: 'from=\\S+&to=\\S+',
+        query: 'from=\\S+&to=\\S+&geolocationMechanism=GPS',
         response: sampleLocations,
       })
 

--- a/server/controllers/locationData/persons.test.ts
+++ b/server/controllers/locationData/persons.test.ts
@@ -1,4 +1,3 @@
-import { RestClient } from '@ministryofjustice/hmpps-rest-client'
 import { ZodError } from 'zod/v4'
 import logger from '../../../logger'
 import createMockPerson from '../../testutils/createMockPerson'
@@ -6,25 +5,18 @@ import createMockRequest from '../../testutils/createMockRequest'
 import createMockResponse from '../../testutils/createMockResponse'
 import PersonsService from '../../services/personsService'
 import PersonsController from './persons'
+import CrimeMatchingClient from '../../data/crimeMatchingClient'
 
-jest.mock('@ministryofjustice/hmpps-rest-client')
+jest.mock('../../data/crimeMatchingClient')
 jest.mock('../../../logger')
 
 const mockPerson = createMockPerson()
 
 describe('PersonsController', () => {
-  let mockRestClient: jest.Mocked<RestClient>
+  let mockRestClient: jest.Mocked<CrimeMatchingClient>
 
   beforeEach(() => {
-    mockRestClient = new RestClient(
-      'crimeMatchingApi',
-      {
-        url: '',
-        timeout: { response: 0, deadline: 0 },
-        agent: { timeout: 0 },
-      },
-      logger,
-    ) as jest.Mocked<RestClient>
+    mockRestClient = new CrimeMatchingClient(logger) as jest.Mocked<CrimeMatchingClient>
   })
 
   afterEach(() => {
@@ -45,7 +37,7 @@ describe('PersonsController', () => {
       const service = new PersonsService(mockRestClient)
       const controller = new PersonsController(service)
 
-      mockRestClient.get.mockResolvedValue({
+      mockRestClient.getPersonsBySearchTerm.mockResolvedValue({
         data: [mockPerson],
         pageCount: 1,
         pageNumber: 1,
@@ -56,16 +48,16 @@ describe('PersonsController', () => {
       await controller.view(req, res, next)
 
       // Then
-      expect(mockRestClient.get).toHaveBeenCalledWith(
+      expect(mockRestClient.getPersonsBySearchTerm).toHaveBeenCalledWith(
         {
-          path: '/persons',
-          query: {
-            name: 'foo',
-            includeDeviceActivations: true,
-            page: '1',
+          tokenType: 'SYSTEM_TOKEN',
+          user: {
+            username: 'fakeUserName',
           },
         },
-        undefined,
+        'name',
+        'foo',
+        '1',
       )
       expect(res.render).toHaveBeenCalledWith('pages/locationData/index', {
         formData: {},
@@ -90,7 +82,7 @@ describe('PersonsController', () => {
       const service = new PersonsService(mockRestClient)
       const controller = new PersonsController(service)
 
-      mockRestClient.get.mockResolvedValue({
+      mockRestClient.getPersonsBySearchTerm.mockResolvedValue({
         data: [mockPerson],
         pageCount: 1,
         pageNumber: 1,
@@ -101,16 +93,16 @@ describe('PersonsController', () => {
       await controller.view(req, res, next)
 
       // Then
-      expect(mockRestClient.get).toHaveBeenCalledWith(
+      expect(mockRestClient.getPersonsBySearchTerm).toHaveBeenCalledWith(
         {
-          path: '/persons',
-          query: {
-            nomisId: 'foo',
-            includeDeviceActivations: true,
-            page: '1',
+          tokenType: 'SYSTEM_TOKEN',
+          user: {
+            username: 'fakeUserName',
           },
         },
-        undefined,
+        'nomisId',
+        'foo',
+        '1',
       )
       expect(res.render).toHaveBeenCalledWith('pages/locationData/index', {
         formData: {},
@@ -135,7 +127,7 @@ describe('PersonsController', () => {
       const service = new PersonsService(mockRestClient)
       const controller = new PersonsController(service)
 
-      mockRestClient.get.mockResolvedValue({
+      mockRestClient.getPersonsBySearchTerm.mockResolvedValue({
         data: [mockPerson],
         pageCount: 1,
         pageNumber: 1,
@@ -146,16 +138,16 @@ describe('PersonsController', () => {
       await controller.view(req, res, next)
 
       // Then
-      expect(mockRestClient.get).toHaveBeenCalledWith(
+      expect(mockRestClient.getPersonsBySearchTerm).toHaveBeenCalledWith(
         {
-          path: '/persons',
-          query: {
-            deviceId: 'foo',
-            includeDeviceActivations: true,
-            page: '1',
+          tokenType: 'SYSTEM_TOKEN',
+          user: {
+            username: 'fakeUserName',
           },
         },
-        undefined,
+        'deviceId',
+        'foo',
+        '1',
       )
       expect(res.render).toHaveBeenCalledWith('pages/locationData/index', {
         formData: {},
@@ -179,7 +171,7 @@ describe('PersonsController', () => {
       await controller.view(req, res, next)
 
       // Then
-      expect(mockRestClient.get).not.toHaveBeenCalled()
+      expect(mockRestClient.getPersonsBySearchTerm).not.toHaveBeenCalled()
       expect(res.render).toHaveBeenCalledWith('pages/locationData/index', {
         formData: {},
         searchField: undefined,
@@ -202,7 +194,7 @@ describe('PersonsController', () => {
       const service = new PersonsService(mockRestClient)
       const controller = new PersonsController(service)
 
-      mockRestClient.get.mockResolvedValue({
+      mockRestClient.getPersonsBySearchTerm.mockResolvedValue({
         data: [],
         pageCount: 1,
         pageNumber: 1,
@@ -213,16 +205,16 @@ describe('PersonsController', () => {
       await controller.view(req, res, next)
 
       // Then
-      expect(mockRestClient.get).toHaveBeenCalledWith(
+      expect(mockRestClient.getPersonsBySearchTerm).toHaveBeenCalledWith(
         {
-          path: '/persons',
-          query: {
-            name: 'foo',
-            includeDeviceActivations: true,
-            page: '1',
+          tokenType: 'SYSTEM_TOKEN',
+          user: {
+            username: 'fakeUserName',
           },
         },
-        undefined,
+        'name',
+        'foo',
+        '1',
       )
       expect(res.render).toHaveBeenCalledWith('pages/locationData/index', {
         formData: {},
@@ -248,7 +240,7 @@ describe('PersonsController', () => {
       const service = new PersonsService(mockRestClient)
       const controller = new PersonsController(service)
 
-      mockRestClient.get.mockResolvedValue({
+      mockRestClient.getPersonsBySearchTerm.mockResolvedValue({
         data: [mockPerson],
         pageCount: 2,
         pageNumber: 2,
@@ -259,16 +251,16 @@ describe('PersonsController', () => {
       await controller.view(req, res, next)
 
       // Then
-      expect(mockRestClient.get).toHaveBeenCalledWith(
+      expect(mockRestClient.getPersonsBySearchTerm).toHaveBeenCalledWith(
         {
-          path: '/persons',
-          query: {
-            name: 'foo',
-            includeDeviceActivations: true,
-            page: '2',
+          tokenType: 'SYSTEM_TOKEN',
+          user: {
+            username: 'fakeUserName',
           },
         },
-        undefined,
+        'name',
+        'foo',
+        '2',
       )
       expect(res.render).toHaveBeenCalledWith('pages/locationData/index', {
         formData: {},
@@ -376,7 +368,6 @@ describe('PersonsController', () => {
       await controller.search(req, res, next)
 
       // Then
-      expect(mockRestClient.post).not.toHaveBeenCalled()
       expect(res.redirect).toHaveBeenCalledWith('/location-data/persons')
       expect(req.session.validationErrors).toEqual([
         {

--- a/server/controllers/locationData/persons.ts
+++ b/server/controllers/locationData/persons.ts
@@ -8,13 +8,13 @@ export default class PersonsController {
 
   view: RequestHandler = async (req, res) => {
     const { query } = req
-    const { token } = res.locals.user
+    const { username } = res.locals.user
     const parsedQuery = personsQueryParametersSchema.parse(query)
 
     const { searchField, searchTerm } = parsedQuery
 
     if (searchField && searchTerm) {
-      const queryResults = await this.service.getPersons(token, searchField, searchTerm, parsedQuery.page)
+      const queryResults = await this.service.getPersons(username, searchField, searchTerm, parsedQuery.page)
       res.render('pages/locationData/index', {
         origin: req.originalUrl,
         persons: queryResults.data,

--- a/server/controllers/locationData/subject.ts
+++ b/server/controllers/locationData/subject.ts
@@ -58,7 +58,7 @@ export default class SubjectController {
   }
 
   view: RequestHandler = async (req, res) => {
-    const { token } = res.locals.user
+    const { username } = res.locals.user
     const { query, deviceActivation } = req
     const { from, to } = viewLocationsQueryParametersSchema.parse(query)
     const fromDate = parseDateTimeFromISOString(from)
@@ -71,7 +71,7 @@ export default class SubjectController {
 
     if (validationResult.success) {
       const positions = await this.deviceActivationsService.getDeviceActivationPositions(
-        token,
+        username,
         deviceActivation!,
         fromDate,
         toDate,
@@ -127,7 +127,7 @@ export default class SubjectController {
   }
 
   download: RequestHandler = async (req, res, next) => {
-    const { token } = res.locals.user
+    const { username } = res.locals.user
     const { query, deviceActivation } = req
     const { from, to, reportType } = downloadLocationsQueryParameterSchema.parse(query)
     const fromDate = parseDateTimeFromISOString(from)
@@ -139,9 +139,9 @@ export default class SubjectController {
     )
 
     if (validationResult.success) {
-      const deviceWearerPromise = this.personsService.getPerson(token, deviceActivation!.personId)
+      const deviceWearerPromise = this.personsService.getPerson(username, deviceActivation!.personId)
       const positionsPromise = this.deviceActivationsService.getDeviceActivationPositions(
-        token,
+        username,
         deviceActivation!,
         fromDate,
         toDate,

--- a/server/data/crimeMatchingClient.ts
+++ b/server/data/crimeMatchingClient.ts
@@ -1,0 +1,66 @@
+import { AuthOptions, AuthenticationClient, RestClient } from '@ministryofjustice/hmpps-rest-client'
+import Logger from 'bunyan'
+import config from '../config'
+
+export default class CrimeMatchingClient extends RestClient {
+  constructor(logger: Logger, authenticationClient?: AuthenticationClient) {
+    super('Crime Matching Api', config.apis.crimeMatchingApi, logger, authenticationClient)
+  }
+
+  getDeviceActivation(authOptions: AuthOptions, deviceActivationId: string): Promise<unknown> {
+    return this.get(
+      {
+        path: `/device-activations/${deviceActivationId}`,
+      },
+      authOptions,
+    )
+  }
+
+  getDeviceActivationPositions(
+    authOptions: AuthOptions,
+    deviceActivationId: number,
+    from: string,
+    to: string,
+    geolocationMechanism: string,
+  ): Promise<unknown> {
+    return this.get(
+      {
+        path: `/device-activations/${deviceActivationId}/positions`,
+        query: {
+          from,
+          to,
+          geolocationMechanism,
+        },
+      },
+      authOptions,
+    )
+  }
+
+  getPerson(authOptions: AuthOptions, personId: number): Promise<unknown> {
+    return this.get(
+      {
+        path: `/persons/${personId}`,
+      },
+      authOptions,
+    )
+  }
+
+  getPersonsBySearchTerm(
+    authOptions: AuthOptions,
+    searchField: string,
+    searchTerm: string,
+    page: string,
+  ): Promise<unknown> {
+    return this.get(
+      {
+        path: '/persons',
+        query: {
+          [searchField]: searchTerm,
+          includeDeviceActivations: true,
+          page,
+        },
+      },
+      authOptions,
+    )
+  }
+}

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -4,7 +4,6 @@
  * In particular, applicationinsights automatically collects bunyan logs
  */
 import { AuthenticationClient, InMemoryTokenStore, RedisTokenStore } from '@ministryofjustice/hmpps-auth-clients'
-import { RestClient } from '@ministryofjustice/hmpps-rest-client'
 import { initialiseAppInsights, buildAppInsightsClient } from '../utils/azureAppInsights'
 import applicationInfoSupplier from '../applicationInfo'
 
@@ -16,6 +15,7 @@ import { createRedisClient } from './redisClient'
 import config from '../config'
 import HmppsAuditClient from './hmppsAuditClient'
 import logger from '../../logger'
+import CrimeMatchingClient from './crimeMatchingClient'
 
 export const dataAccess = () => {
   const hmppsAuthClient = new AuthenticationClient(
@@ -28,7 +28,7 @@ export const dataAccess = () => {
     applicationInfo,
     hmppsAuthClient,
     hmppsAuditClient: new HmppsAuditClient(config.sqs.audit),
-    crimeMatchingApiClient: new RestClient('CrimeMatchingApi', config.apis.crimeMatchingApi, logger, hmppsAuthClient),
+    crimeMatchingApiClient: new CrimeMatchingClient(logger, hmppsAuthClient),
   }
 }
 

--- a/server/middleware/populateDeviceActivation.test.ts
+++ b/server/middleware/populateDeviceActivation.test.ts
@@ -1,11 +1,11 @@
-import { RestClient } from '@ministryofjustice/hmpps-rest-client'
 import createMockRequest from '../testutils/createMockRequest'
 import createMockResponse from '../testutils/createMockResponse'
 import DeviceActivationsService from '../services/deviceActivationsService'
 import populateDeviceActivation from './populateDeviceActivation'
 import logger from '../../logger'
+import CrimeMatchingClient from '../data/crimeMatchingClient'
 
-jest.mock('@ministryofjustice/hmpps-rest-client')
+jest.mock('../data/crimeMatchingClient')
 jest.mock('../../logger')
 
 const notFoundResponse = {
@@ -29,20 +29,12 @@ const successResponse = {
 }
 
 describe('populateDeviceActivation', () => {
-  let restClient: jest.Mocked<RestClient>
+  let restClient: jest.Mocked<CrimeMatchingClient>
 
   beforeEach(() => {
     jest.resetAllMocks()
 
-    restClient = new RestClient(
-      'crimeMatchingApi',
-      {
-        url: '',
-        timeout: { response: 0, deadline: 0 },
-        agent: { timeout: 0 },
-      },
-      logger,
-    ) as jest.Mocked<RestClient>
+    restClient = new CrimeMatchingClient(logger) as jest.Mocked<CrimeMatchingClient>
   })
 
   it('should throw an error when the device activation was not found', async () => {
@@ -53,7 +45,7 @@ describe('populateDeviceActivation', () => {
     const service = new DeviceActivationsService(restClient)
 
     // Stub a 404 response from the API
-    restClient.get.mockRejectedValue({
+    restClient.getDeviceActivation.mockRejectedValue({
       message: 'Not Found',
       name: 'Not Found',
       stack: '',
@@ -77,7 +69,7 @@ describe('populateDeviceActivation', () => {
     const service = new DeviceActivationsService(restClient)
 
     // Stub a 200 response from the API
-    restClient.get.mockResolvedValue(successResponse)
+    restClient.getDeviceActivation.mockResolvedValue(successResponse)
 
     // When
     await populateDeviceActivation(service)(req, res, next, '123456789', 'deviceActivationId')

--- a/server/middleware/populateDeviceActivation.ts
+++ b/server/middleware/populateDeviceActivation.ts
@@ -6,8 +6,8 @@ const populateDeviceActivation =
   (deviceActivationsService: DeviceActivationsService): RequestParamHandler =>
   async (req: Request, res: Response, next: NextFunction, deviceActivationId: string) => {
     try {
-      const { token } = res.locals.user
-      const deviceActivation = await deviceActivationsService.getDeviceActivation(token, deviceActivationId)
+      const { username } = res.locals.user
+      const deviceActivation = await deviceActivationsService.getDeviceActivation(username, deviceActivationId)
 
       req.deviceActivation = deviceActivation
       next()

--- a/server/routes/location-data.test.ts
+++ b/server/routes/location-data.test.ts
@@ -1,27 +1,19 @@
 import request from 'supertest'
-import { RestClient } from '@ministryofjustice/hmpps-rest-client'
 import { appWithAllRoutes, user } from './testutils/appSetup'
 import logger from '../../logger'
 import DeviceActivationsService from '../services/deviceActivationsService'
 import ValidationService from '../services/locationData/validationService'
 import PersonsService from '../services/personsService'
+import CrimeMatchingClient from '../data/crimeMatchingClient'
 
-jest.mock('@ministryofjustice/hmpps-rest-client')
+jest.mock('../data/crimeMatchingClient')
 jest.mock('../../logger')
 
 describe('/location-data', () => {
-  let restClient: jest.Mocked<RestClient>
+  let restClient: jest.Mocked<CrimeMatchingClient>
 
   beforeEach(() => {
-    restClient = new RestClient(
-      'crimeMatchingApi',
-      {
-        url: '',
-        timeout: { response: 0, deadline: 0 },
-        agent: { timeout: 0 },
-      },
-      logger,
-    ) as jest.Mocked<RestClient>
+    restClient = new CrimeMatchingClient(logger) as jest.Mocked<CrimeMatchingClient>
   })
 
   afterEach(() => {
@@ -65,7 +57,7 @@ describe('/location-data', () => {
         userSupplier: () => user,
       })
 
-      restClient.get.mockRejectedValue({
+      restClient.getDeviceActivation.mockRejectedValue({
         message: 'Not Found',
         name: 'Not Found',
         stack: '',
@@ -95,7 +87,7 @@ describe('/location-data', () => {
         userSupplier: () => user,
       })
 
-      restClient.get.mockResolvedValueOnce({
+      restClient.getDeviceActivation.mockResolvedValueOnce({
         data: {
           deviceActivationId: 123456789,
           deviceId: 123456789,

--- a/server/services/deviceActivationsService.ts
+++ b/server/services/deviceActivationsService.ts
@@ -1,20 +1,16 @@
-import { asSystem, RestClient } from '@ministryofjustice/hmpps-rest-client'
+import { asSystem } from '@ministryofjustice/hmpps-rest-client'
 import { Dayjs } from 'dayjs'
 import Position from '../types/entities/position'
 import { getDeviceActivationDtoSchema, getDeviceActivationPositionsDtoSchema } from '../schemas/dtos/deviceActivation'
 import DeviceActivation from '../types/entities/deviceActivation'
 import { SortDirection, sortPositionsByTimestamp } from '../utils/sort'
+import CrimeMatchingClient from '../data/crimeMatchingClient'
 
 class DeviceActivationsService {
-  constructor(private readonly crimeMatchingApiClient: RestClient) {}
+  constructor(private readonly crimeMatchingApiClient: CrimeMatchingClient) {}
 
   async getDeviceActivation(username: string, deviceActivationId: string): Promise<DeviceActivation> {
-    const response = await this.crimeMatchingApiClient.get(
-      {
-        path: `/device-activations/${deviceActivationId}`,
-      },
-      asSystem(username),
-    )
+    const response = await this.crimeMatchingApiClient.getDeviceActivation(asSystem(username), deviceActivationId)
 
     return getDeviceActivationDtoSchema.parse(response).data
   }
@@ -25,15 +21,12 @@ class DeviceActivationsService {
     fromDate: Dayjs,
     toDate: Dayjs,
   ): Promise<Array<Position>> {
-    const response = await this.crimeMatchingApiClient.get(
-      {
-        path: `/device-activations/${deviceActivation.deviceActivationId}/positions`,
-        query: {
-          from: fromDate.toISOString(),
-          to: toDate.toISOString(),
-        },
-      },
+    const response = await this.crimeMatchingApiClient.getDeviceActivationPositions(
       asSystem(username),
+      deviceActivation.deviceActivationId,
+      fromDate.toISOString(),
+      toDate.toISOString(),
+      'GPS',
     )
 
     return getDeviceActivationPositionsDtoSchema

--- a/server/services/deviceActivationsService.ts
+++ b/server/services/deviceActivationsService.ts
@@ -1,4 +1,4 @@
-import { asUser, RestClient } from '@ministryofjustice/hmpps-rest-client'
+import { asSystem, RestClient } from '@ministryofjustice/hmpps-rest-client'
 import { Dayjs } from 'dayjs'
 import Position from '../types/entities/position'
 import { getDeviceActivationDtoSchema, getDeviceActivationPositionsDtoSchema } from '../schemas/dtos/deviceActivation'
@@ -8,19 +8,19 @@ import { SortDirection, sortPositionsByTimestamp } from '../utils/sort'
 class DeviceActivationsService {
   constructor(private readonly crimeMatchingApiClient: RestClient) {}
 
-  async getDeviceActivation(token: string, deviceActivationId: string): Promise<DeviceActivation> {
+  async getDeviceActivation(username: string, deviceActivationId: string): Promise<DeviceActivation> {
     const response = await this.crimeMatchingApiClient.get(
       {
         path: `/device-activations/${deviceActivationId}`,
       },
-      asUser(token),
+      asSystem(username),
     )
 
     return getDeviceActivationDtoSchema.parse(response).data
   }
 
   async getDeviceActivationPositions(
-    token: string,
+    username: string,
     deviceActivation: DeviceActivation,
     fromDate: Dayjs,
     toDate: Dayjs,
@@ -33,7 +33,7 @@ class DeviceActivationsService {
           to: toDate.toISOString(),
         },
       },
-      asUser(token),
+      asSystem(username),
     )
 
     return getDeviceActivationPositionsDtoSchema

--- a/server/services/personsService.ts
+++ b/server/services/personsService.ts
@@ -1,34 +1,25 @@
-import { asSystem, RestClient } from '@ministryofjustice/hmpps-rest-client'
+import { asSystem } from '@ministryofjustice/hmpps-rest-client'
 import { getPersonDtoSchema, getPersonsDtoSchema } from '../schemas/dtos/person'
 import GetPersonsDto from '../types/dtos/persons'
 import Person from '../types/entities/person'
+import CrimeMatchingClient from '../data/crimeMatchingClient'
 
 class PersonsService {
-  constructor(private readonly crimeMatchingApiClient: RestClient) {}
+  constructor(private readonly crimeMatchingApiClient: CrimeMatchingClient) {}
 
   async getPersons(username: string, searchField: string, searchTerm: string, page: string): Promise<GetPersonsDto> {
-    const response = await this.crimeMatchingApiClient.get(
-      {
-        path: '/persons',
-        query: {
-          [searchField]: searchTerm,
-          includeDeviceActivations: true,
-          page,
-        },
-      },
+    const response = await this.crimeMatchingApiClient.getPersonsBySearchTerm(
       asSystem(username),
+      searchField,
+      searchTerm,
+      page,
     )
 
     return getPersonsDtoSchema.parse(response)
   }
 
   async getPerson(username: string, personId: number): Promise<Person> {
-    const response = await this.crimeMatchingApiClient.get(
-      {
-        path: `/persons/${personId}`,
-      },
-      asSystem(username),
-    )
+    const response = await this.crimeMatchingApiClient.getPerson(asSystem(username), personId)
 
     return getPersonDtoSchema.parse(response).data
   }

--- a/server/services/personsService.ts
+++ b/server/services/personsService.ts
@@ -1,4 +1,4 @@
-import { asUser, RestClient } from '@ministryofjustice/hmpps-rest-client'
+import { asSystem, RestClient } from '@ministryofjustice/hmpps-rest-client'
 import { getPersonDtoSchema, getPersonsDtoSchema } from '../schemas/dtos/person'
 import GetPersonsDto from '../types/dtos/persons'
 import Person from '../types/entities/person'
@@ -6,7 +6,7 @@ import Person from '../types/entities/person'
 class PersonsService {
   constructor(private readonly crimeMatchingApiClient: RestClient) {}
 
-  async getPersons(token: string, searchField: string, searchTerm: string, page: string): Promise<GetPersonsDto> {
+  async getPersons(username: string, searchField: string, searchTerm: string, page: string): Promise<GetPersonsDto> {
     const response = await this.crimeMatchingApiClient.get(
       {
         path: '/persons',
@@ -16,18 +16,18 @@ class PersonsService {
           page,
         },
       },
-      asUser(token),
+      asSystem(username),
     )
 
     return getPersonsDtoSchema.parse(response)
   }
 
-  async getPerson(token: string, personId: number): Promise<Person> {
+  async getPerson(username: string, personId: number): Promise<Person> {
     const response = await this.crimeMatchingApiClient.get(
       {
         path: `/persons/${personId}`,
       },
-      asUser(token),
+      asSystem(username),
     )
 
     return getPersonDtoSchema.parse(response).data


### PR DESCRIPTION
## Configuration

Follow the instructions to get the API running. Update the env vars to include: `EM_CRIME_MATCHING_API_URL=http://localhost:8080`

## Geolocation mechanism

Location data is filtered to only GPS positions.

## Auth

The auth implementation follows the hmpps-auth guidance:

> We should use the authorization_code flow only to authorise an end user to access a frontend service.  The token may be used to retrieve basic user data and check what user roles a user has, but it must not be used to make API calls.  API calls should be made with a system-system token obtained via the client_credentials flow

Therefore, we use the `asSystem` auth options helper to make requests to the API. The UI hmpps-auth client must therefore be configured with the `ROLE_EM_CRIME_MATCHING_GENERAL_RO` role in order to be authorized to access API endpoints. 

We will need to update this service to authorise users based on their assigned roles, currently allow any authenticated user to use the service.

## Rest client

Implemented a `CrimeMatchingClient` that inherits from `RestClient`. I think this is the intended usage compared to how we were doing it before and it allows us to validate the token being sent in requests. Previously the `jest.mock('@ministryofjustice/hmpps-rest-client')` was also mocking the `asUser` & and `asSystem` methods so they always returned `undefined` in tests.

## Stubs

Undeploy the stubs from dev, leaving them in the repo in case we want them for demos (because they'll be faster).