### PR TITLE
Fix map initialisation error

### DIFF
--- a/server/controllers/locationData/subject.ts
+++ b/server/controllers/locationData/subject.ts
@@ -110,7 +110,10 @@ export default class SubjectController {
         },
         origin: req.originalUrl,
         apiKey: config.maps.apiKey,
-        geoJson: JSON.stringify({}),
+        geoJson: {
+          type: 'FeatureCollection',
+          features: [],
+        },
         tileUrl: config.maps.tileUrl,
         alerts: [],
         formData: {


### PR DESCRIPTION
The locations layer was throwing `Cannot read properties of undefined (reading 'filter')` when trying to filter the geoJson locations if there was no location data.

This fixes the format of the geoJson object to always contain an empty array of features.