### PR TITLE
Make marker appear above confidence circle

### DIFF
--- a/assets/js/views/proximity-alert/crimeVersion.ts
+++ b/assets/js/views/proximity-alert/crimeVersion.ts
@@ -92,6 +92,7 @@ const addCrimeLayers = (emMap: EmMap, crime: CrimePosition): { centre: Coordinat
 
   const crimeMarkerLayer = new LocationsLayer({
     positions: [crimeWithMarker],
+    zIndex: 10,
   })
 
   // Add a Crime 100m radius circle


### PR DESCRIPTION
The `crimeRadius` layer had a higher zIndex than the `crimeMarkerLayer` , causing the alpha value (0.12) of the `crimeRadius` layer to also be applied to the marker layer.

## New

<img width="457" height="367" alt="Screenshot 2026-04-13 at 10 49 56" src="https://github.com/user-attachments/assets/8e3af712-65af-4556-b943-6c662d549f6c" />

## Old

<img width="515" height="343" alt="Screenshot 2026-04-13 at 10 50 01" src="https://github.com/user-attachments/assets/ff1d597c-0218-4b23-b99b-80b44cdfafab" />



