### PR TITLE
Refactor proximity alert using layer groups

### DIFF
--- a/assets/js/views/proximity-alert/crimeVersion.ts
+++ b/assets/js/views/proximity-alert/crimeVersion.ts
@@ -4,24 +4,7 @@ import type { Coordinate } from 'ol/coordinate'
 import { queryElement } from '../../utils/utils'
 import CrimeLayer from './layers/crime'
 import DeviceWearerLayer from './layers/deviceWearer'
-
-type WearerPosition = {
-  positionType: 'wearer'
-  latitude: number
-  longitude: number
-  precision: number
-  timestamp: string
-  sequenceLabel: string
-  deviceId: number
-}
-
-type CrimePosition = {
-  positionType: 'crime'
-  latitude: number
-  longitude: number
-  radiusMeters: number
-  crimeTypeId: string
-}
+import { CrimePosition, WearerPosition } from './types'
 
 type ProximityAlertMapPosition = WearerPosition | CrimePosition
 

--- a/assets/js/views/proximity-alert/crimeVersion.ts
+++ b/assets/js/views/proximity-alert/crimeVersion.ts
@@ -1,15 +1,9 @@
 import { EmMap } from '@ministryofjustice/hmpps-electronic-monitoring-components/map'
-import {
-  LocationsLayer,
-  CirclesLayer,
-  TextLayer,
-  TracksLayer,
-} from '@ministryofjustice/hmpps-electronic-monitoring-components/map/layers'
-import { createEmpty } from 'ol/extent'
 import { fromLonLat } from 'ol/proj'
 import type { Coordinate } from 'ol/coordinate'
-import LayerGroup from 'ol/layer/Group'
 import { queryElement } from '../../utils/utils'
+import CrimeLayer from './layers/crime'
+import DeviceWearerLayer from './layers/deviceWearer'
 
 type WearerPosition = {
   positionType: 'wearer'
@@ -29,35 +23,7 @@ type CrimePosition = {
   crimeTypeId: string
 }
 
-type CrimePositionWithMarker = CrimePosition & {
-  marker: {
-    type: 'pin'
-    pin: {
-      color: string
-    }
-  }
-}
-
 type ProximityAlertMapPosition = WearerPosition | CrimePosition
-
-type Extent = ReturnType<typeof createEmpty>
-type SourceWithExtent = { getExtent?: () => Extent }
-type LayerWithSource = {
-  getSource?: () => SourceWithExtent | undefined
-  setVisible?: (visible: boolean) => void
-}
-
-type WearerLayers = {
-  locations?: LayerWithSource
-  labels?: LayerWithSource
-  tracks?: LayerWithSource
-}
-
-type CircleInput = {
-  latitude: number
-  longitude: number
-  precision: number
-}
 
 const palette = [
   '#d00050',
@@ -82,58 +48,7 @@ const palette = [
 const addCrimeLayers = (emMap: EmMap, crime: CrimePosition): { centre: Coordinate } => {
   const centre = fromLonLat([crime.longitude, crime.latitude])
 
-  const crimeWithMarker: CrimePositionWithMarker = {
-    ...crime,
-    marker: {
-      type: 'pin',
-      pin: { color: '#d4351c' },
-    },
-  }
-
-  const crimeMarkerLayer = new LocationsLayer({
-    positions: [crimeWithMarker],
-    zIndex: 10,
-  })
-
-  // Add a Crime 100m radius circle
-  const circlePos: CircleInput = {
-    latitude: crime.latitude,
-    longitude: crime.longitude,
-    precision: 100,
-  }
-
-  const crimeRadius = new CirclesLayer({
-    id: 'crime-radius',
-    title: 'crime-radius',
-    zIndex: 1,
-    visible: true,
-    style: {
-      fill: 'rgba(0, 0, 0, 0.12)',
-      stroke: { color: 'rgba(0, 0, 0, 0.45)', width: 2 },
-    },
-    positions: [circlePos],
-  })
-
-  const crimeTypeLabel = new TextLayer({
-    id: `labels-crime-type`,
-    title: `labels-crime-type`,
-    positions: [crime],
-    textProperty: 'crimeTypeId',
-    zIndex: 5,
-    visible: true,
-    style: {
-      fill: '#d4351c',
-      offset: { x: 0, y: 20 },
-      textAlign: 'center',
-    },
-  })
-
-  const layerGroup = new LayerGroup({
-    layers: [...crimeMarkerLayer.getLayers(), ...crimeRadius.getLayers(), ...crimeTypeLabel.getLayers()],
-  })
-
-  layerGroup.set('id', 'crimeLayer')
-  emMap.addLayerGroup(layerGroup)
+  emMap.addLayerGroup(new CrimeLayer(crime))
 
   return { centre }
 }
@@ -172,54 +87,12 @@ const initialiseProximityAlertView = async () => {
     positionsByWearer.set(key, list)
   }
 
-  const layersByWearer = new Map<number, WearerLayers>()
-
   let colourIndex = 0
   for (const [deviceId, positions] of positionsByWearer.entries()) {
     const colour = palette[colourIndex % palette.length]
     colourIndex += 1
 
-    const locations = emMap.addLayer(
-      new LocationsLayer({
-        id: `device-wearer-positions-${deviceId}`,
-        title: `locations-${deviceId}`,
-        positions,
-        zIndex: 4,
-        style: {
-          fill: colour,
-          stroke: { color: colour, width: 0 },
-        },
-      }),
-    ) as unknown as LayerWithSource
-
-    const tracks = emMap.addLayer(
-      new TracksLayer({
-        id: `device-wearer-tracks-${deviceId}`,
-        title: `device-wearer-tracks-${deviceId}`,
-        positions,
-        entryExit: {
-          enabled: true,
-          extensionDistanceMeters: 100,
-          centre: [crime.latitude, crime.longitude],
-          radiusMeters: 100,
-        },
-        zIndex: 2,
-        visible: false,
-      }),
-    ) as unknown as LayerWithSource
-
-    const labels = emMap.addLayer(
-      new TextLayer({
-        id: `labels-${deviceId}`,
-        title: `labels-${deviceId}`,
-        positions,
-        textProperty: 'sequenceLabel',
-        zIndex: 5,
-        visible: true,
-      }),
-    ) as unknown as LayerWithSource
-
-    layersByWearer.set(deviceId, { locations, tracks, labels })
+    emMap.addLayerGroup(new DeviceWearerLayer(deviceId, crime, positions, colour))
   }
 
   emMap.dispatchEvent(

--- a/assets/js/views/proximity-alert/layers/crime.ts
+++ b/assets/js/views/proximity-alert/layers/crime.ts
@@ -1,0 +1,78 @@
+import {
+  CirclesLayer,
+  LocationsLayer,
+  TextLayer,
+} from '@ministryofjustice/hmpps-electronic-monitoring-components/map/layers'
+import LayerGroup from 'ol/layer/Group'
+
+type CrimePosition = {
+  positionType: 'crime'
+  latitude: number
+  longitude: number
+  radiusMeters: number
+  crimeTypeId: string
+}
+
+class CrimeLayer extends LayerGroup {
+  constructor(crime: CrimePosition) {
+    super({
+      properties: {
+        title: 'crime',
+      },
+      layers: [
+        // Crime radius
+        ...new CirclesLayer({
+          title: 'crime-radius',
+          zIndex: 1,
+          visible: true,
+          style: {
+            fill: 'rgba(0, 0, 0, 0.12)',
+            stroke: {
+              color: 'rgba(0, 0, 0, 0.45)',
+              width: 2,
+            },
+          },
+          positions: [
+            {
+              latitude: crime.latitude,
+              longitude: crime.longitude,
+              // @ts-expect-error missing from type but is used
+              precision: 100,
+            },
+          ],
+        }).getLayers(),
+
+        // Crime type label
+        ...new TextLayer({
+          title: 'crime-type',
+          positions: [crime],
+          textProperty: 'crimeTypeId',
+          zIndex: 5,
+          visible: true,
+          style: {
+            fill: '#d4351c',
+            offset: { x: 0, y: 20 },
+            textAlign: 'center',
+          },
+        }).getLayers(),
+
+        // Marker
+        ...new LocationsLayer({
+          title: 'crime-marker',
+          positions: [
+            {
+              ...crime,
+              marker: {
+                type: 'pin',
+                pin: { color: '#d4351c' },
+              },
+            },
+          ],
+          zIndex: 10,
+        }).getLayers(),
+      ],
+    })
+  }
+}
+
+export default CrimeLayer

--- a/assets/js/views/proximity-alert/layers/crime.ts
+++ b/assets/js/views/proximity-alert/layers/crime.ts
@@ -4,14 +4,7 @@ import {
   TextLayer,
 } from '@ministryofjustice/hmpps-electronic-monitoring-components/map/layers'
 import LayerGroup from 'ol/layer/Group'
-
-type CrimePosition = {
-  positionType: 'crime'
-  latitude: number
-  longitude: number
-  radiusMeters: number
-  crimeTypeId: string
-}
+import { CrimePosition } from '../types'
 
 class CrimeLayer extends LayerGroup {
   constructor(crime: CrimePosition) {

--- a/assets/js/views/proximity-alert/layers/deviceWearer.ts
+++ b/assets/js/views/proximity-alert/layers/deviceWearer.ts
@@ -4,24 +4,7 @@ import {
   TracksLayer,
 } from '@ministryofjustice/hmpps-electronic-monitoring-components/map/layers'
 import LayerGroup from 'ol/layer/Group'
-
-type WearerPosition = {
-  positionType: 'wearer'
-  latitude: number
-  longitude: number
-  precision: number
-  timestamp: string
-  sequenceLabel: string
-  deviceId: number
-}
-
-type CrimePosition = {
-  positionType: 'crime'
-  latitude: number
-  longitude: number
-  radiusMeters: number
-  crimeTypeId: string
-}
+import { CrimePosition, WearerPosition } from '../types'
 
 class DeviceWearerLayer extends LayerGroup {
   constructor(deviceId: number, crime: CrimePosition, positions: Array<WearerPosition>, colour: string) {

--- a/assets/js/views/proximity-alert/layers/deviceWearer.ts
+++ b/assets/js/views/proximity-alert/layers/deviceWearer.ts
@@ -1,0 +1,74 @@
+import {
+  LocationsLayer,
+  TextLayer,
+  TracksLayer,
+} from '@ministryofjustice/hmpps-electronic-monitoring-components/map/layers'
+import LayerGroup from 'ol/layer/Group'
+
+type WearerPosition = {
+  positionType: 'wearer'
+  latitude: number
+  longitude: number
+  precision: number
+  timestamp: string
+  sequenceLabel: string
+  deviceId: number
+}
+
+type CrimePosition = {
+  positionType: 'crime'
+  latitude: number
+  longitude: number
+  radiusMeters: number
+  crimeTypeId: string
+}
+
+class DeviceWearerLayer extends LayerGroup {
+  constructor(deviceId: number, crime: CrimePosition, positions: Array<WearerPosition>, colour: string) {
+    super({
+      properties: {
+        title: `device-wearer-${deviceId}`,
+      },
+      layers: [
+        // Tracks
+        ...new TracksLayer({
+          id: `device-wearer-tracks-${deviceId}`,
+          title: `device-wearer-tracks-${deviceId}`,
+          positions,
+          entryExit: {
+            enabled: true,
+            extensionDistanceMeters: 100,
+            centre: [crime.latitude, crime.longitude],
+            radiusMeters: 100,
+          },
+          zIndex: 2,
+          visible: false,
+        }).getLayers(),
+
+        // Labels
+        ...new TextLayer({
+          id: `device-wearer-labels-${deviceId}`,
+          title: `device-wearer-labels-${deviceId}`,
+          positions,
+          textProperty: 'sequenceLabel',
+          zIndex: 5,
+          visible: true,
+        }).getLayers(),
+
+        // Locations
+        ...new LocationsLayer({
+          id: `device-wearer-positions-${deviceId}`,
+          title: `device-wearer-positions-${deviceId}`,
+          positions,
+          zIndex: 4,
+          style: {
+            fill: colour,
+            stroke: { color: colour, width: 0 },
+          },
+        }).getLayers(),
+      ],
+    })
+  }
+}
+
+export default DeviceWearerLayer

--- a/assets/js/views/proximity-alert/layers/deviceWearer.ts
+++ b/assets/js/views/proximity-alert/layers/deviceWearer.ts
@@ -32,7 +32,6 @@ class DeviceWearerLayer extends LayerGroup {
       layers: [
         // Tracks
         ...new TracksLayer({
-          id: `device-wearer-tracks-${deviceId}`,
           title: `device-wearer-tracks-${deviceId}`,
           positions,
           entryExit: {
@@ -47,7 +46,6 @@ class DeviceWearerLayer extends LayerGroup {
 
         // Labels
         ...new TextLayer({
-          id: `device-wearer-labels-${deviceId}`,
           title: `device-wearer-labels-${deviceId}`,
           positions,
           textProperty: 'sequenceLabel',
@@ -57,7 +55,6 @@ class DeviceWearerLayer extends LayerGroup {
 
         // Locations
         ...new LocationsLayer({
-          id: `device-wearer-positions-${deviceId}`,
           title: `device-wearer-positions-${deviceId}`,
           positions,
           zIndex: 4,

--- a/assets/js/views/proximity-alert/types.ts
+++ b/assets/js/views/proximity-alert/types.ts
@@ -1,0 +1,17 @@
+export type WearerPosition = {
+  positionType: 'wearer'
+  latitude: number
+  longitude: number
+  precision: number
+  timestamp: string
+  sequenceLabel: string
+  deviceId: number
+}
+
+export type CrimePosition = {
+  positionType: 'crime'
+  latitude: number
+  longitude: number
+  radiusMeters: number
+  crimeTypeId: string
+}

--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
@@ -68,7 +68,7 @@ context('Crime Version', () => {
 
       // And the crime version details
       page.map.sidebar.shouldHaveVersionLabel('Latest Version')
-      page.map.sidebar.crimeToggle.shouldBeChecked('crimeLayer')
+      page.map.sidebar.crimeToggle.shouldBeChecked('crime')
       page.map.sidebar.crimeToggle.shouldHaveText('crimeRefAggravated Burglary')
 
       page.map.sidebar.crimeVersionSummaryList.shouldExist()
@@ -118,7 +118,7 @@ context('Crime Version', () => {
 
       // And the crime version details
       page.map.sidebar.shouldHaveVersionLabel('Latest Version')
-      page.map.sidebar.crimeToggle.shouldBeChecked('crimeLayer')
+      page.map.sidebar.crimeToggle.shouldBeChecked('crime')
       page.map.sidebar.crimeToggle.shouldHaveText('crimeRefAggravated Burglary')
 
       page.map.sidebar.crimeVersionSummaryList.shouldExist()
@@ -199,7 +199,7 @@ context('Crime Version', () => {
 
       // And the crime version details
       page.map.sidebar.shouldHaveVersionLabel('Latest Version')
-      page.map.sidebar.crimeToggle.shouldBeChecked('crimeLayer')
+      page.map.sidebar.crimeToggle.shouldBeChecked('crime')
       page.map.sidebar.crimeToggle.shouldHaveText('crimeRefAggravated Burglary')
 
       page.map.sidebar.crimeVersionSummaryList.shouldExist()

--- a/server/views/pages/proximityAlert/partials/reports.njk
+++ b/server/views/pages/proximityAlert/partials/reports.njk
@@ -20,7 +20,7 @@
         },
         items: [
           {
-            value: "crimeLayer",
+            value: "crime",
             html: "<strong>" + crimeVersion.crimeReference + "</strong><br>" + "<strong>" + crimeVersion.crimeTypeDescription + "</strong>",
             checked: true
           }
@@ -138,8 +138,8 @@
           value: 'device-wearer-tracks-' + deviceWearer.deviceId
         },
         {
-          id: 'device-wearer-positions-' + deviceWearer.deviceId,
-          value: 'device-wearer-positions-' + deviceWearer.deviceId,
+          id: 'device-wearer-' + deviceWearer.deviceId,
+          value: 'device-wearer-' + deviceWearer.deviceId,
           text: "Include",
           checked: true
         }


### PR DESCRIPTION
- Refactors the proximity alert to use 2 distinct layer groups 
  - CrimeLayer
  - DeviceWearerLayer
- Having a single layer for `DeviceWearerLayer` means the "Include" toggle will toggle the visibility of all layers for a single device wearer (e.g. tracks, positions, text, circles)
- Applied consistent naming pattern to all layers (kebab-case) 

## Demo

https://github.com/user-attachments/assets/bf3cc058-c6b5-4698-b305-383039e74800

