### PR TITLE
Make analysis toggle work in proximity alert view

### DIFF
--- a/assets/js/components/map-layer-visibility-toggle.ts
+++ b/assets/js/components/map-layer-visibility-toggle.ts
@@ -15,7 +15,15 @@ class MapLayerVisibilityToggle extends Component {
   }
 
   setLayerVisibility(layerId: string, visible: boolean) {
-    this.map.setLayerVisibility(layerId, visible)
+    const re = new RegExp(layerId)
+    const layers = this.map.olMapInstance?.getAllLayers() || []
+    const layerGroups = this.map.olMapInstance?.getLayerGroup().getLayers().getArray() || []
+
+    for (const layer of [...layerGroups, ...layers]) {
+      if (re.test(layer.get('title'))) {
+        layer.setVisible(visible)
+      }
+    }
   }
 
   handleClick(event: MouseEvent) {

--- a/server/views/pages/proximityAlert/crimeVersion.njk
+++ b/server/views/pages/proximityAlert/crimeVersion.njk
@@ -25,12 +25,12 @@
       },
       items: [
         {
-          value: "confidenceLayer",
+          value: "device-wearer-circles-",
           text: "Show confidence circles",
           checked: true
         },
         {
-          value: "numberingLayer",
+          value: "device-wearer-labels-",
           text: "Show location numbering",
           checked: true
         }


### PR DESCRIPTION
- Updates the `MapLayerVisibilityToggle` component to match layers using patterns
- This allows easy toggling of all numbering layers using the pattern `device-wearer-labels-` or confidence circles using `device-wearer-circles-`

## Demo

https://github.com/user-attachments/assets/b048aeba-f778-4d4e-b32c-f26453fc5115

> N.B. The confidence circle layers haven't been added yet.