### PR TITLE
Add confidence circles to proximity alert map

### DIFF
--- a/assets/js/views/proximity-alert/layers/deviceWearer.ts
+++ b/assets/js/views/proximity-alert/layers/deviceWearer.ts
@@ -1,4 +1,5 @@
 import {
+  CirclesLayer,
   LocationsLayer,
   TextLayer,
   TracksLayer,
@@ -34,6 +35,22 @@ class DeviceWearerLayer extends LayerGroup {
           textProperty: 'sequenceLabel',
           zIndex: 5,
           visible: true,
+        }).getLayers(),
+
+        // Confidence circles
+        ...new CirclesLayer({
+          title: `device-wearer-circles-${deviceId}`,
+          positions,
+          visible: true,
+          zIndex: 3,
+          style: {
+            fill: null,
+            stroke: {
+              color: 'rgba(242, 201, 76, 1)',
+              lineDash: [8, 8],
+              width: 2,
+            },
+          },
         }).getLayers(),
 
         // Locations

--- a/server/controllers/proximityAlert/crimeVersion.test.ts
+++ b/server/controllers/proximityAlert/crimeVersion.test.ts
@@ -128,7 +128,7 @@ describe('CrimeVersionController', () => {
             crimeTypeId: 'AB',
           },
           {
-            confidence: 10,
+            precision: 10,
             deviceId: 1,
             geolocationMechanism: 'GPS',
             latitude: 10,
@@ -140,7 +140,7 @@ describe('CrimeVersionController', () => {
             timestamp: '2025-01-01T00:00',
           },
           {
-            confidence: 10,
+            precision: 10,
             deviceId: 1,
             geolocationMechanism: 'GPS',
             latitude: 10,

--- a/server/presenters/proximityAlert/mapPositions.ts
+++ b/server/presenters/proximityAlert/mapPositions.ts
@@ -5,7 +5,7 @@ export type ProximityAlertMapPosition =
       positionType: 'wearer'
       latitude: number
       longitude: number
-      confidence: number
+      precision: number
       timestamp: string
       sequenceLabel: string
       geolocationMechanism: string
@@ -36,7 +36,7 @@ export default function toProximityAlertMapPositions(crimeVersion: CrimeVersion)
         positionType: 'wearer' as const,
         latitude: pos.latitude,
         longitude: pos.longitude,
-        confidence: pos.confidence,
+        precision: pos.confidence,
         timestamp: pos.capturedDateTime,
         sequenceLabel: pos.sequenceLabel,
         geolocationMechanism: 'GPS' as const,


### PR DESCRIPTION
- Confirmed with Hil that numbers and confidence circles should show on page load.
- Minor change to the presenter to use `precision` rather than `confidence` as thats what the map lib uses.

## Demo




https://github.com/user-attachments/assets/f1b2623e-8a9a-42dc-81eb-25fabe510a5a



