### PR TITLE
Add proximity alert map interaction tests

### DIFF
--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
@@ -4,7 +4,7 @@ import CrimeVersionPage from '../../pages/proximityAlert/crimeVersion'
 const crimeVersionId = '64d41bd9-5450-4bbb-89d4-42ba75659f49'
 
 context('Crime Version', () => {
-  context('Get Crime Version', () => {
+  context('Viewing a crime version', () => {
     beforeEach(() => {
       cy.task('reset')
       cy.task('stubSignIn')
@@ -53,7 +53,7 @@ context('Crime Version', () => {
       })
 
       // When the user loads the page
-      cy.visit('/proximity-alert/64d41bd9-5450-4bbb-89d4-42ba75659f49')
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
 
       const page = Page.verifyOnPage(CrimeVersionPage)
 
@@ -103,7 +103,7 @@ context('Crime Version', () => {
       })
 
       // When the user loads the page
-      cy.visit('/proximity-alert/64d41bd9-5450-4bbb-89d4-42ba75659f49')
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
 
       const page = Page.verifyOnPage(CrimeVersionPage)
 

--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
@@ -1,0 +1,343 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
+import Map from 'ol/Map'
+import BaseLayer from 'ol/layer/Base'
+import Page from '../../pages/page'
+import CrimeVersionPage from '../../pages/proximityAlert/crimeVersion'
+
+const crimeVersionId = '64d41bd9-5450-4bbb-89d4-42ba75659f49'
+
+const getTitle = (layer: BaseLayer): string => {
+  const title = layer.get('title')
+
+  if (title && typeof title === 'string') {
+    return title
+  }
+
+  return ''
+}
+
+const getLayers = (map: Map, pattern: RegExp = /device-wearer-.*/): Array<{ title: string; visible: boolean }> => {
+  return map
+    .getAllLayers()
+    .filter(layer => pattern.test(getTitle(layer)))
+    .map(layer => ({ title: getTitle(layer), visible: layer.isVisible() }))
+}
+
+context('Crime Version', () => {
+  context('Viewing a crime Version', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn')
+      cy.signIn()
+      cy.stubMapMiddleware()
+      cy.stubGetCrimeVersion({
+        status: 200,
+        crimeVersionId: '64d41bd9-5450-4bbb-89d4-42ba75659f49',
+        response: {
+          data: {
+            crimeVersionId,
+            crimeReference: 'crimeRef',
+            crimeTypeDescription: 'Aggravated Burglary',
+            crimeTypeId: 'AB',
+            crimeDateTimeFrom: '2025-01-01T00:00:00Z',
+            crimeDateTimeTo: '2025-01-01T01:00:00Z',
+            crimeText: 'crimeText',
+            longitude: 0,
+            latitude: 0,
+            versionLabel: 'Latest Version',
+            matching: {
+              deviceWearers: [
+                {
+                  name: 'wearer-1',
+                  deviceId: 1,
+                  nomisId: 'nomisId',
+                  positions: [
+                    {
+                      latitude: 0,
+                      longitude: 0,
+                      sequenceLabel: 'A1',
+                      confidence: 10,
+                      capturedDateTime: '2025-01-01T00:00',
+                    },
+                  ],
+                },
+                {
+                  name: 'wearer-2',
+                  deviceId: 2,
+                  nomisId: 'nomisId',
+                  positions: [
+                    {
+                      latitude: 0,
+                      longitude: 0,
+                      sequenceLabel: 'A1',
+                      confidence: 10,
+                      capturedDateTime: '2025-01-01T00:00',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      })
+    })
+
+    it('should show numbers, circles, positions and hide tracks on page load', () => {
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And the map is ready
+      page.map.mapInstance.then(map => {
+        // Then the numbers, circles, positions layers should be shown
+        expect(getLayers(map)).to.deep.eq([
+          { title: 'device-wearer-tracks-1', visible: false },
+          { title: 'device-wearer-labels-1', visible: true },
+          { title: 'device-wearer-circles-1', visible: true },
+          { title: 'device-wearer-positions-1', visible: true },
+          { title: 'device-wearer-tracks-2', visible: false },
+          { title: 'device-wearer-labels-2', visible: true },
+          { title: 'device-wearer-circles-2', visible: true },
+          { title: 'device-wearer-positions-2', visible: true },
+        ])
+      })
+    })
+
+    it('should hide all confidence circle layers', () => {
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And the map is ready
+      page.map.mapInstance.then(map => {
+        // And the user hides confidence circles layers
+        page.map.sidebar.analysisTab.click()
+        page.map.sidebar.analysisToggles.unselect('device-wearer-circles-')
+
+        // Then the circles layers should be hidden
+        cy.wait(100).then(() => {
+          expect(getLayers(map)).to.deep.eq([
+            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-labels-1', visible: true },
+            { title: 'device-wearer-circles-1', visible: false },
+            { title: 'device-wearer-positions-1', visible: true },
+            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-labels-2', visible: true },
+            { title: 'device-wearer-circles-2', visible: false },
+            { title: 'device-wearer-positions-2', visible: true },
+          ])
+        })
+      })
+    })
+
+    it('should hide all numbering layers', () => {
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And the map is ready
+      page.map.mapInstance.then(map => {
+        // And the user hides number layers
+        page.map.sidebar.analysisTab.click()
+        page.map.sidebar.analysisToggles.unselect('device-wearer-labels-')
+
+        // Then the numbering layers should be hidden
+        cy.wait(100).then(() => {
+          expect(getLayers(map)).to.deep.eq([
+            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-labels-1', visible: false },
+            { title: 'device-wearer-circles-1', visible: true },
+            { title: 'device-wearer-positions-1', visible: true },
+            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-labels-2', visible: false },
+            { title: 'device-wearer-circles-2', visible: true },
+            { title: 'device-wearer-positions-2', visible: true },
+          ])
+        })
+      })
+    })
+
+    it('should hide all device wearer layers for wearer-1', () => {
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And the map is ready
+      page.map.mapInstance.then(map => {
+        // And the user hides device wearer 1
+        page.map.sidebar.getDeviceWearerToggles('1').unselect('device-wearer-1')
+
+        // Then the device wearer 1 layers should be hidden
+        cy.wait(100).then(() => {
+          expect(getLayers(map)).to.deep.eq([
+            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-labels-1', visible: false },
+            { title: 'device-wearer-circles-1', visible: false },
+            { title: 'device-wearer-positions-1', visible: false },
+            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-labels-2', visible: true },
+            { title: 'device-wearer-circles-2', visible: true },
+            { title: 'device-wearer-positions-2', visible: true },
+          ])
+        })
+      })
+    })
+
+    it('should hide all device wearer labels for wearer-2', () => {
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And the map is ready
+      page.map.mapInstance.then(map => {
+        // And the user hides device wearer 2
+        page.map.sidebar.getDeviceWearerToggles('2').unselect('device-wearer-2')
+
+        // Then the device wearer 2 layers should be hidden
+        cy.wait(100).then(() => {
+          expect(getLayers(map)).to.deep.eq([
+            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-labels-1', visible: true },
+            { title: 'device-wearer-circles-1', visible: true },
+            { title: 'device-wearer-positions-1', visible: true },
+            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-labels-2', visible: false },
+            { title: 'device-wearer-circles-2', visible: false },
+            { title: 'device-wearer-positions-2', visible: false },
+          ])
+        })
+      })
+    })
+
+    it('should show the tracks layer for device wearer 1', () => {
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And the map is ready
+      page.map.mapInstance.then(map => {
+        // And the user shows the tracks for device wearer 1
+        page.map.sidebar.getDeviceWearerToggles('1').select('device-wearer-tracks-1')
+
+        // Then the device wearer 1 tracks should be shown
+        cy.wait(100).then(() => {
+          expect(getLayers(map)).to.deep.eq([
+            { title: 'device-wearer-tracks-1', visible: true },
+            { title: 'device-wearer-labels-1', visible: true },
+            { title: 'device-wearer-circles-1', visible: true },
+            { title: 'device-wearer-positions-1', visible: true },
+            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-labels-2', visible: true },
+            { title: 'device-wearer-circles-2', visible: true },
+            { title: 'device-wearer-positions-2', visible: true },
+          ])
+        })
+      })
+    })
+
+    it('should show the tracks layer for device wearer 2', () => {
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And the map is ready
+      page.map.mapInstance.then(map => {
+        // And the user shows the tracks for device wearer 1
+        page.map.sidebar.getDeviceWearerToggles('2').select('device-wearer-tracks-2')
+
+        // Then the device wearer 1 tracks should be shown
+        cy.wait(100).then(() => {
+          expect(getLayers(map)).to.deep.eq([
+            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-labels-1', visible: true },
+            { title: 'device-wearer-circles-1', visible: true },
+            { title: 'device-wearer-positions-1', visible: true },
+            { title: 'device-wearer-tracks-2', visible: true },
+            { title: 'device-wearer-labels-2', visible: true },
+            { title: 'device-wearer-circles-2', visible: true },
+            { title: 'device-wearer-positions-2', visible: true },
+          ])
+        })
+      })
+    })
+
+    it('should only show the confidence circles for device wearer 1', () => {
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And the map is ready
+      page.map.mapInstance.then(map => {
+        // And the user hides the confidence circles
+        page.map.sidebar.analysisTab.click()
+        page.map.sidebar.analysisToggles.unselect('device-wearer-circles-')
+
+        // And hides device wearer 2
+        page.map.sidebar.reportsTab.click()
+        page.map.sidebar.getDeviceWearerToggles('2').unselect('device-wearer-2')
+
+        // And then shows the confidence circles
+        page.map.sidebar.analysisTab.click()
+        page.map.sidebar.analysisToggles.select('device-wearer-circles-')
+
+        // Then the device wearer 2 circle layer should remain hidden
+        cy.wait(100).then(() => {
+          expect(getLayers(map)).to.deep.eq([
+            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-labels-1', visible: true },
+            { title: 'device-wearer-circles-1', visible: true },
+            { title: 'device-wearer-positions-1', visible: true },
+            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-labels-2', visible: false },
+            { title: 'device-wearer-circles-2', visible: false },
+            { title: 'device-wearer-positions-2', visible: false },
+          ])
+        })
+      })
+    })
+
+    it('should only show the numbering layer for device wearer 1', () => {
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And the map is ready
+      page.map.mapInstance.then(map => {
+        // And the user hides the numbering layers
+        page.map.sidebar.analysisTab.click()
+        page.map.sidebar.analysisToggles.unselect('device-wearer-labels-')
+
+        // And hides device wearer 2
+        page.map.sidebar.reportsTab.click()
+        page.map.sidebar.getDeviceWearerToggles('2').unselect('device-wearer-2')
+
+        // And then shows the numbering layers
+        page.map.sidebar.analysisTab.click()
+        page.map.sidebar.analysisToggles.select('device-wearer-labels-')
+
+        // Then the device wearer 2 circle layer should remain hidden
+        cy.wait(100).then(() => {
+          expect(getLayers(map)).to.deep.eq([
+            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-labels-1', visible: true },
+            { title: 'device-wearer-circles-1', visible: true },
+            { title: 'device-wearer-positions-1', visible: true },
+            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-labels-2', visible: false },
+            { title: 'device-wearer-circles-2', visible: false },
+            { title: 'device-wearer-positions-2', visible: false },
+          ])
+        })
+      })
+    })
+  })
+})

--- a/integration_tests/pages/components/mapComponent.ts
+++ b/integration_tests/pages/components/mapComponent.ts
@@ -44,7 +44,11 @@ export default class MapComponent {
           }
         }
 
-        el.addEventListener('app:map:layers:ready', handler, { once: true })
+        if (el.olMapInstance) {
+          resolve(el.olMapInstance)
+        } else {
+          el.addEventListener('app:map:layers:ready', handler, { once: true })
+        }
       })
     })
   }

--- a/integration_tests/pages/components/mapSidebarComponent.ts
+++ b/integration_tests/pages/components/mapSidebarComponent.ts
@@ -57,6 +57,10 @@ export default class MapSidebarComponent {
 
   // HELPERS
 
+  getDeviceWearerToggles(id: string) {
+    return new FormCheckboxesComponent(this.element, `device-wearer-toggle-${id}`)
+  }
+
   shouldExist(): void {
     this.element.should('exist')
   }

--- a/server/views/pages/proximityAlert/crimeVersion.njk
+++ b/server/views/pages/proximityAlert/crimeVersion.njk
@@ -19,7 +19,7 @@
     govukCheckboxes({
       id: "analysis-toggles",
       classes: "govuk-checkboxes--small",
-      name: "analysisToggles",
+      name: "analysis-toggles",
       attributes: {
         "data-module": 'map-layer-visibility-toggle'
       },

--- a/server/views/pages/proximityAlert/partials/reports.njk
+++ b/server/views/pages/proximityAlert/partials/reports.njk
@@ -125,9 +125,9 @@
 
   {{
     govukCheckboxes({
-      id: 'analysis-toggles-' + deviceWearer.deviceId,
+      id: 'device-wearer-toggle-' + deviceWearer.deviceId,
       classes: "govuk-checkboxes--small",
-      name: "deviceWearerToggle-" + deviceWearer.deviceId,
+      name: "device-wearer-toggle-" + deviceWearer.deviceId,
       attributes: {
         "data-module": 'map-layer-visibility-toggle'
       },


### PR DESCRIPTION
This change adds tests for the map interactions. It uses the states of the OL layers to determine when the interactive components have worked correctly.

## Why do we check every layer in every test?

Every tests asserts the state of every device wearer layer (e.g. all positions, circles, tracks and numbering layers). 

This is to prevent any future regressions that may occur as a result of the map visibility toggles using regex to match the layer to be shown / hidden - it would be very easy to accidentally have side effects where toggles interact with the wrong layers.

## Why `cy.wait()`?

I initially tried to use the built in open layers events that get emitted when the state of the map changes, but this was
incredibly flaky and really hard to get correct. This is even more complex when applying multiple interactions (e.g. hiding and subsequently showing a layer) as multiple `rendercomplete` events would be fired. 

```ts 
map.on('rendercomplete', () => {
  // assertions
})
```

`cy.wait()` seems like the least flaky option that I tried and allows a more procedural setup of the test scenarios too, whereas, in the event handler scenario, the assertions would have to be written before the interactions were invoked.

e.g.

```ts 
// Setup assertions
map.on('rendercomplete', () => {
  // assertions
})

// Invoke interactions
page.map.sidebar.getDeviceWearerToggles('1').unselect('device-wearer-1')
```
