### PR TITLE
Allow users to select / deselect all device wearers

### DIFF
--- a/assets/js/components/index.ts
+++ b/assets/js/components/index.ts
@@ -1,6 +1,7 @@
 import MapFocusOnLayer from './map-focus-on-layer'
 import MapLayerVisibilityToggle from './map-layer-visibility-toggle'
+import SelectAll from './select-all'
 
-const components = [MapLayerVisibilityToggle, MapFocusOnLayer]
+const components = [MapLayerVisibilityToggle, MapFocusOnLayer, SelectAll]
 
 export default components

--- a/assets/js/components/map-layer-visibility-toggle.ts
+++ b/assets/js/components/map-layer-visibility-toggle.ts
@@ -27,14 +27,14 @@ class MapLayerVisibilityToggle extends Component {
   }
 
   handleChange(event: Event) {
-    const $clickedInput = event.target
+    const $changedInput = event.target
 
     // Ignore clicks on things that aren't checkbox inputs
-    if (!($clickedInput instanceof HTMLInputElement) || $clickedInput.type !== 'checkbox') {
+    if (!($changedInput instanceof HTMLInputElement) || $changedInput.type !== 'checkbox') {
       return
     }
 
-    this.setLayerVisibility($clickedInput.value, $clickedInput.checked)
+    this.setLayerVisibility($changedInput.value, $changedInput.checked)
   }
 
   static moduleName = 'map-layer-visibility-toggle'

--- a/assets/js/components/map-layer-visibility-toggle.ts
+++ b/assets/js/components/map-layer-visibility-toggle.ts
@@ -9,7 +9,7 @@ class MapLayerVisibilityToggle extends Component {
     super($root)
 
     // Handle events
-    this.$root.addEventListener('click', event => this.handleClick(event))
+    this.$root.addEventListener('change', event => this.handleChange(event))
 
     this.map = queryElement(document, 'em-map') as EmMap
   }
@@ -26,7 +26,7 @@ class MapLayerVisibilityToggle extends Component {
     }
   }
 
-  handleClick(event: MouseEvent) {
+  handleChange(event: Event) {
     const $clickedInput = event.target
 
     // Ignore clicks on things that aren't checkbox inputs

--- a/assets/js/components/select-all.ts
+++ b/assets/js/components/select-all.ts
@@ -1,0 +1,78 @@
+import { Component } from 'govuk-frontend'
+
+/**
+ * Select All Component
+ *
+ * This allows a single checkbox element to select many other checkbox elements
+ * if their value matches the pattern defined in the value of the control checkbox.
+ */
+class SelectAll extends Component {
+  private targets: Array<HTMLInputElement>
+
+  private syncing: boolean = false
+
+  constructor($root: Element) {
+    super($root)
+
+    // Find targets
+    this.targets = this.getTargets()
+
+    // Handle events
+    this.$input.addEventListener('click', event => this.handleClick(event))
+
+    // Handle updates to targets
+    for (const target of this.targets) {
+      target.addEventListener('change', () => this.handleTargetChange())
+    }
+  }
+
+  private get $input(): HTMLInputElement {
+    return this.$root.querySelector('input[type="checkbox"]') as HTMLInputElement
+  }
+
+  private getTargets(): Array<HTMLInputElement> {
+    const re = new RegExp(this.$input.value)
+    const allCheckboxes = document.querySelectorAll("input[type='checkbox']").entries()
+
+    return [...allCheckboxes]
+      .filter(([_, element]) => re.test((element as HTMLInputElement).value))
+      .map(([_, e]) => e as HTMLInputElement)
+  }
+
+  /**
+   * Updates the state of the target checkboxes and fire a 'change' event. The
+   * syncing state is recorded.
+   */
+  private updateTargets(checked: boolean): void {
+    this.syncing = true
+
+    for (const checkbox of this.targets) {
+      checkbox.checked = checked
+      checkbox.dispatchEvent(new Event('change', { bubbles: true }))
+    }
+
+    this.syncing = false
+  }
+
+  /**
+   * Update the state of the "select all" if a target checkbox is changed.
+   * Because "selecting all" will trigger "change" events in target checkboxes,
+   * we do not update the state of this checkbox if already updating
+   */
+  private handleTargetChange(): void {
+    if (!this.syncing) {
+      this.$input.checked = this.targets.every(target => target.checked)
+    }
+  }
+
+  /**
+   * When the "select all" checkbox is clicked, update all target checkboxes
+   */
+  private handleClick(event: MouseEvent): void {
+    this.updateTargets((event.target as HTMLInputElement).checked)
+  }
+
+  static moduleName = 'select-all'
+}
+
+export default SelectAll

--- a/assets/js/components/select-all.ts
+++ b/assets/js/components/select-all.ts
@@ -4,7 +4,7 @@ import { Component } from 'govuk-frontend'
  * Select All Component
  *
  * This allows a single checkbox element to select many other checkbox elements
- * if their value matches the pattern defined in the value of the control checkbox.
+ * if their name matches the value of the control checkbox.
  */
 class SelectAll extends Component {
   private targets: Array<HTMLInputElement>
@@ -31,12 +31,9 @@ class SelectAll extends Component {
   }
 
   private getTargets(): Array<HTMLInputElement> {
-    const re = new RegExp(this.$input.value)
-    const allCheckboxes = document.querySelectorAll("input[type='checkbox']").entries()
-
-    return [...allCheckboxes]
-      .filter(([_, element]) => re.test((element as HTMLInputElement).value))
-      .map(([_, e]) => e as HTMLInputElement)
+    return [...document.querySelectorAll(`input[type='checkbox'][name=${this.$input.value}]`).entries()].map(
+      ([_, element]) => element as HTMLInputElement,
+    )
   }
 
   /**

--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
@@ -68,7 +68,7 @@ context('Crime Version', () => {
 
       // And the crime version details
       page.map.sidebar.shouldHaveVersionLabel('Latest Version')
-      page.map.sidebar.crimeToggle.shouldBeChecked('crime')
+      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-\\\\d+')
       page.map.sidebar.crimeToggle.shouldHaveText('crimeRefAggravated Burglary')
 
       page.map.sidebar.crimeVersionSummaryList.shouldExist()
@@ -118,7 +118,7 @@ context('Crime Version', () => {
 
       // And the crime version details
       page.map.sidebar.shouldHaveVersionLabel('Latest Version')
-      page.map.sidebar.crimeToggle.shouldBeChecked('crime')
+      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-\\\\d+')
       page.map.sidebar.crimeToggle.shouldHaveText('crimeRefAggravated Burglary')
 
       page.map.sidebar.crimeVersionSummaryList.shouldExist()
@@ -199,7 +199,7 @@ context('Crime Version', () => {
 
       // And the crime version details
       page.map.sidebar.shouldHaveVersionLabel('Latest Version')
-      page.map.sidebar.crimeToggle.shouldBeChecked('crime')
+      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-\\\\d+')
       page.map.sidebar.crimeToggle.shouldHaveText('crimeRefAggravated Burglary')
 
       page.map.sidebar.crimeVersionSummaryList.shouldExist()

--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
@@ -68,7 +68,7 @@ context('Crime Version', () => {
 
       // And the crime version details
       page.map.sidebar.shouldHaveVersionLabel('Latest Version')
-      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-\\\\d+')
+      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-toggle')
       page.map.sidebar.crimeToggle.shouldHaveText('crimeRefAggravated Burglary')
 
       page.map.sidebar.crimeVersionSummaryList.shouldExist()
@@ -118,7 +118,7 @@ context('Crime Version', () => {
 
       // And the crime version details
       page.map.sidebar.shouldHaveVersionLabel('Latest Version')
-      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-\\\\d+')
+      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-toggle')
       page.map.sidebar.crimeToggle.shouldHaveText('crimeRefAggravated Burglary')
 
       page.map.sidebar.crimeVersionSummaryList.shouldExist()
@@ -199,7 +199,7 @@ context('Crime Version', () => {
 
       // And the crime version details
       page.map.sidebar.shouldHaveVersionLabel('Latest Version')
-      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-\\\\d+')
+      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-toggle')
       page.map.sidebar.crimeToggle.shouldHaveText('crimeRefAggravated Burglary')
 
       page.map.sidebar.crimeVersionSummaryList.shouldExist()

--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
@@ -339,5 +339,76 @@ context('Crime Version', () => {
         })
       })
     })
+
+    it('should hide and show all selected device wearer layers', () => {
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And the map is ready
+      page.map.mapInstance.then(map => {
+        // And the user hides all device wearer layers
+        page.map.sidebar.crimeToggle.unselect('device-wearer-\\d+')
+
+        // Then the device wearer "include" toggles should be unchecked
+        page.map.sidebar.getDeviceWearerToggles('1').shouldNotBeChecked('device-wearer-1')
+        page.map.sidebar.getDeviceWearerToggles('2').shouldNotBeChecked('device-wearer-2')
+
+        // Then the device wearer layers should be hidden
+        cy.wait(100).then(() => {
+          expect(getLayers(map)).to.deep.eq([
+            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-labels-1', visible: false },
+            { title: 'device-wearer-circles-1', visible: false },
+            { title: 'device-wearer-positions-1', visible: false },
+            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-labels-2', visible: false },
+            { title: 'device-wearer-circles-2', visible: false },
+            { title: 'device-wearer-positions-2', visible: false },
+          ])
+        })
+
+        // And the user shows all device wearer layers
+        page.map.sidebar.crimeToggle.select('device-wearer-\\d+')
+
+        // Then the device wearer "include" toggles should be unchecked
+        page.map.sidebar.getDeviceWearerToggles('1').shouldBeChecked('device-wearer-1')
+        page.map.sidebar.getDeviceWearerToggles('2').shouldBeChecked('device-wearer-2')
+
+        // Then the device wearer layers should be shown
+        cy.wait(100).then(() => {
+          expect(getLayers(map)).to.deep.eq([
+            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-labels-1', visible: true },
+            { title: 'device-wearer-circles-1', visible: true },
+            { title: 'device-wearer-positions-1', visible: true },
+            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-labels-2', visible: true },
+            { title: 'device-wearer-circles-2', visible: true },
+            { title: 'device-wearer-positions-2', visible: true },
+          ])
+        })
+      })
+    })
+
+    it('should sync the "select all" checkbox with the device wearer "include" checkboxes', () => {
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And unchecks one of the device wearer "include" layers
+      page.map.sidebar.getDeviceWearerToggles('1').unselect('device-wearer-1')
+
+      // Then the "select all" checkbox should be unchecked
+      page.map.sidebar.crimeToggle.shouldNotBeChecked('device-wearer-\\\\d+')
+
+      // And when the user has selected all of the device wearer "include" layers
+      page.map.sidebar.getDeviceWearerToggles('1').select('device-wearer-1')
+
+      // Then the "select all" checkbox should be checked
+      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-\\\\d+')
+    })
   })
 })

--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
@@ -169,7 +169,7 @@ context('Crime Version', () => {
       // And the map is ready
       page.map.mapInstance.then(map => {
         // And the user hides device wearer 1
-        page.map.sidebar.getDeviceWearerToggles('1').unselect('device-wearer-1')
+        page.map.sidebar.deviceWearerToggles.unselect('device-wearer-1')
 
         // Then the device wearer 1 layers should be hidden
         cy.wait(100).then(() => {
@@ -196,7 +196,7 @@ context('Crime Version', () => {
       // And the map is ready
       page.map.mapInstance.then(map => {
         // And the user hides device wearer 2
-        page.map.sidebar.getDeviceWearerToggles('2').unselect('device-wearer-2')
+        page.map.sidebar.deviceWearerToggles.unselect('device-wearer-2')
 
         // Then the device wearer 2 layers should be hidden
         cy.wait(100).then(() => {
@@ -223,7 +223,7 @@ context('Crime Version', () => {
       // And the map is ready
       page.map.mapInstance.then(map => {
         // And the user shows the tracks for device wearer 1
-        page.map.sidebar.getDeviceWearerToggles('1').select('device-wearer-tracks-1')
+        page.map.sidebar.deviceWearerTrackToggles.select('device-wearer-tracks-1')
 
         // Then the device wearer 1 tracks should be shown
         cy.wait(100).then(() => {
@@ -250,7 +250,7 @@ context('Crime Version', () => {
       // And the map is ready
       page.map.mapInstance.then(map => {
         // And the user shows the tracks for device wearer 1
-        page.map.sidebar.getDeviceWearerToggles('2').select('device-wearer-tracks-2')
+        page.map.sidebar.deviceWearerTrackToggles.select('device-wearer-tracks-2')
 
         // Then the device wearer 1 tracks should be shown
         cy.wait(100).then(() => {
@@ -282,7 +282,7 @@ context('Crime Version', () => {
 
         // And hides device wearer 2
         page.map.sidebar.reportsTab.click()
-        page.map.sidebar.getDeviceWearerToggles('2').unselect('device-wearer-2')
+        page.map.sidebar.deviceWearerToggles.unselect('device-wearer-2')
 
         // And then shows the confidence circles
         page.map.sidebar.analysisTab.click()
@@ -318,7 +318,7 @@ context('Crime Version', () => {
 
         // And hides device wearer 2
         page.map.sidebar.reportsTab.click()
-        page.map.sidebar.getDeviceWearerToggles('2').unselect('device-wearer-2')
+        page.map.sidebar.deviceWearerToggles.unselect('device-wearer-2')
 
         // And then shows the numbering layers
         page.map.sidebar.analysisTab.click()
@@ -349,11 +349,11 @@ context('Crime Version', () => {
       // And the map is ready
       page.map.mapInstance.then(map => {
         // And the user hides all device wearer layers
-        page.map.sidebar.crimeToggle.unselect('device-wearer-\\d+')
+        page.map.sidebar.crimeToggle.unselect('device-wearer-toggle')
 
         // Then the device wearer "include" toggles should be unchecked
-        page.map.sidebar.getDeviceWearerToggles('1').shouldNotBeChecked('device-wearer-1')
-        page.map.sidebar.getDeviceWearerToggles('2').shouldNotBeChecked('device-wearer-2')
+        page.map.sidebar.deviceWearerToggles.shouldNotBeChecked('device-wearer-1')
+        page.map.sidebar.deviceWearerToggles.shouldNotBeChecked('device-wearer-2')
 
         // Then the device wearer layers should be hidden
         cy.wait(100).then(() => {
@@ -370,11 +370,11 @@ context('Crime Version', () => {
         })
 
         // And the user shows all device wearer layers
-        page.map.sidebar.crimeToggle.select('device-wearer-\\d+')
+        page.map.sidebar.crimeToggle.select('device-wearer-toggle')
 
         // Then the device wearer "include" toggles should be unchecked
-        page.map.sidebar.getDeviceWearerToggles('1').shouldBeChecked('device-wearer-1')
-        page.map.sidebar.getDeviceWearerToggles('2').shouldBeChecked('device-wearer-2')
+        page.map.sidebar.deviceWearerToggles.shouldBeChecked('device-wearer-1')
+        page.map.sidebar.deviceWearerToggles.shouldBeChecked('device-wearer-2')
 
         // Then the device wearer layers should be shown
         cy.wait(100).then(() => {
@@ -399,16 +399,16 @@ context('Crime Version', () => {
       const page = Page.verifyOnPage(CrimeVersionPage)
 
       // And unchecks one of the device wearer "include" layers
-      page.map.sidebar.getDeviceWearerToggles('1').unselect('device-wearer-1')
+      page.map.sidebar.deviceWearerToggles.unselect('device-wearer-1')
 
       // Then the "select all" checkbox should be unchecked
-      page.map.sidebar.crimeToggle.shouldNotBeChecked('device-wearer-\\\\d+')
+      page.map.sidebar.crimeToggle.shouldNotBeChecked('device-wearer-toggle')
 
       // And when the user has selected all of the device wearer "include" layers
-      page.map.sidebar.getDeviceWearerToggles('1').select('device-wearer-1')
+      page.map.sidebar.deviceWearerToggles.select('device-wearer-1')
 
       // Then the "select all" checkbox should be checked
-      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-\\\\d+')
+      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-toggle')
     })
   })
 })

--- a/integration_tests/pages/components/formCheckboxesComponent.ts
+++ b/integration_tests/pages/components/formCheckboxesComponent.ts
@@ -24,7 +24,7 @@ export default class FormCheckboxesComponent {
     this.element.filter(`[value="${value}"]`).should('be.checked')
   }
 
-  shouldNotBeChecked(value) {
+  shouldNotBeChecked(value: string) {
     this.element.filter(`[value="${value}"]`).should('not.be.checked')
   }
 

--- a/integration_tests/pages/components/mapSidebarComponent.ts
+++ b/integration_tests/pages/components/mapSidebarComponent.ts
@@ -57,8 +57,12 @@ export default class MapSidebarComponent {
 
   // HELPERS
 
-  getDeviceWearerToggles(id: string) {
-    return new FormCheckboxesComponent(this.element, `device-wearer-toggle-${id}`)
+  get deviceWearerToggles() {
+    return new FormCheckboxesComponent(this.element, 'device-wearer-toggle')
+  }
+
+  get deviceWearerTrackToggles() {
+    return new FormCheckboxesComponent(this.element, 'device-wearer-tracks')
   }
 
   shouldExist(): void {

--- a/server/views/pages/proximityAlert/partials/reports.njk
+++ b/server/views/pages/proximityAlert/partials/reports.njk
@@ -16,11 +16,11 @@
         classes: "govuk-checkboxes--small",
         name: "crime-toggle",
         attributes: {
-          "data-module": 'map-layer-visibility-toggle'
+          "data-module": 'select-all'
         },
         items: [
           {
-            value: "crime",
+            value: "device-wearer-\\d+",
             html: "<strong>" + crimeVersion.crimeReference + "</strong><br>" + "<strong>" + crimeVersion.crimeTypeDescription + "</strong>",
             checked: true
           }

--- a/server/views/pages/proximityAlert/partials/reports.njk
+++ b/server/views/pages/proximityAlert/partials/reports.njk
@@ -20,7 +20,7 @@
         },
         items: [
           {
-            value: "device-wearer-\\d+",
+            value: "device-wearer-toggle",
             html: "<strong>" + crimeVersion.crimeReference + "</strong><br>" + "<strong>" + crimeVersion.crimeTypeDescription + "</strong>",
             checked: true
           }
@@ -135,12 +135,14 @@
         {
           id: 'device-wearer-tracks-' + deviceWearer.deviceId,
           text: "Show tracks",
+          name: 'device-wearer-tracks',
           value: 'device-wearer-tracks-' + deviceWearer.deviceId
         },
         {
           id: 'device-wearer-' + deviceWearer.deviceId,
           value: 'device-wearer-' + deviceWearer.deviceId,
           text: "Include",
+          name: 'device-wearer-toggle',
           checked: true
         }
       ]


### PR DESCRIPTION
The checkbox next to the crime reference label is intended to behave as a "select all" checkbox. When it's "selected", all "Include" checkboxes should be "selected". When its "unselected", all "Include" checkboxes should be "unselected".

## Refactored input names

Prior to this change, we grouped checkbox inputs by device wearer. This change retains the visual grouping but changes the `name` of the checkbox to reflect the type of Layer / LayerGroup it interacts with. This is done so that we can more easily interact with groups of similar inputs (e.g. using a "select all" component).

## SelectAll Component

- Added a `SelectAll` component that selects other checkboxes based on their `name`. 
- In the below example, a `govukCheckbox` is setup that will select all other checkboxes that have the name `crime`.

```nunjucks
{{
  govukCheckboxes({
    attributes: {
      "data-module": 'select-all'
    },
    items: [
      {
        value: "crime",
        text: "test",
        checked: true
      }
    ]
  })
}}
```

## MapLayerVisibilityToggle Component

- The `MapLayerVisibilityToggle` has changed from using `click` events to `change` events. This is to support the checkboxes being changed from a source other than a user "clicking" the checkbox.

## Demo

https://github.com/user-attachments/assets/9d9b32fd-02c1-4422-9bf6-46326e7391bb