### PR TITLE
Test view on map behaviour

### DIFF
--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
@@ -1,6 +1,7 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
 import Map from 'ol/Map'
 import BaseLayer from 'ol/layer/Base'
+import { transform } from 'ol/proj'
 import Page from '../../pages/page'
 import CrimeVersionPage from '../../pages/proximityAlert/crimeVersion'
 
@@ -42,8 +43,8 @@ context('Crime Version', () => {
             crimeDateTimeFrom: '2025-01-01T00:00:00Z',
             crimeDateTimeTo: '2025-01-01T01:00:00Z',
             crimeText: 'crimeText',
-            longitude: 0,
-            latitude: 0,
+            longitude: -2.528865717,
+            latitude: 53.43157277,
             versionLabel: 'Latest Version',
             matching: {
               deviceWearers: [
@@ -53,8 +54,8 @@ context('Crime Version', () => {
                   nomisId: 'nomisId',
                   positions: [
                     {
-                      latitude: 0,
-                      longitude: 0,
+                      longitude: -2.528865717,
+                      latitude: 53.43157277,
                       sequenceLabel: 'A1',
                       confidence: 10,
                       capturedDateTime: '2025-01-01T00:00',
@@ -67,8 +68,8 @@ context('Crime Version', () => {
                   nomisId: 'nomisId',
                   positions: [
                     {
-                      latitude: 0,
-                      longitude: 0,
+                      longitude: -2.528865717,
+                      latitude: 53.43157277,
                       sequenceLabel: 'A1',
                       confidence: 10,
                       capturedDateTime: '2025-01-01T00:00',
@@ -355,7 +356,7 @@ context('Crime Version', () => {
         page.map.sidebar.deviceWearerToggles.shouldNotBeChecked('device-wearer-1')
         page.map.sidebar.deviceWearerToggles.shouldNotBeChecked('device-wearer-2')
 
-        // Then the device wearer layers should be hidden
+        // And the device wearer layers should be hidden
         cy.wait(100).then(() => {
           expect(getLayers(map)).to.deep.eq([
             { title: 'device-wearer-tracks-1', visible: false },
@@ -376,7 +377,7 @@ context('Crime Version', () => {
         page.map.sidebar.deviceWearerToggles.shouldBeChecked('device-wearer-1')
         page.map.sidebar.deviceWearerToggles.shouldBeChecked('device-wearer-2')
 
-        // Then the device wearer layers should be shown
+        // And the device wearer layers should be shown
         cy.wait(100).then(() => {
           expect(getLayers(map)).to.deep.eq([
             { title: 'device-wearer-tracks-1', visible: false },
@@ -409,6 +410,32 @@ context('Crime Version', () => {
 
       // Then the "select all" checkbox should be checked
       page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-toggle')
+    })
+
+    it('should focus the map to the crime radius', () => {
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And the map is ready
+      page.map.mapInstance.then(map => {
+        // Then the map should start zoomed out
+        expect(map.getView().getZoom()).to.eq(16.5)
+
+        // And when the user click the "view on map" link
+        page.map.sidebar.viewOnMapLink.click()
+
+        // The fit transition takes 500ms to should definitely be complete after 600ms
+        cy.wait(600).then(() => {
+          // Then the map should be focused on the crime
+          const centre = transform(map.getView().getCenter()!, 'EPSG:3857', 'EPSG:4326')
+
+          expect(centre[0]).to.be.closeTo(-2.528865717, 0.0000001)
+          expect(centre[1]).to.be.closeTo(53.43157277, 0.0000001)
+          expect(map.getView().getZoom()).to.be.closeTo(18.1, 0.1)
+        })
+      })
     })
   })
 })

--- a/integration_tests/pages/components/mapSidebarComponent.ts
+++ b/integration_tests/pages/components/mapSidebarComponent.ts
@@ -43,6 +43,10 @@ export default class MapSidebarComponent {
     return new SummaryListComponent('.crime-version-summary-list')
   }
 
+  get viewOnMapLink() {
+    return this.element.get('.govuk-link')
+  }
+
   get versionLabel() {
     return this.element.get('.govuk-tag')
   }

--- a/integration_tests/pages/components/mapSidebarComponent.ts
+++ b/integration_tests/pages/components/mapSidebarComponent.ts
@@ -44,7 +44,7 @@ export default class MapSidebarComponent {
   }
 
   get viewOnMapLink() {
-    return this.element.get('.govuk-link')
+    return this.element.get('.govuk-link').contains('View on map')
   }
 
   get versionLabel() {


### PR DESCRIPTION
This adds a test to make sure the "view on map" link focuses the map on the crime radius. I'm not sure whether its possible to calculate what the expected `zoom` value should be based on the size of the window, the location / radius of the crime etc. 

For example, on my full screen, when I click "View on map" the zoom hits the threshold (`maxZoom: 19`) but when running it in cypress, it only gets to roughly `18.1`. My assumption is that this is because the cypress window is smaller.

So I think this is more of a regression test to make sure it does "something" rather than a deterministic test that it behaves correctly.