### PR TITLE
Add back button to the proximity alert view

### DIFF
--- a/assets/scss/layouts/_map-container.scss
+++ b/assets/scss/layouts/_map-container.scss
@@ -1,6 +1,6 @@
 .map-container {
   @media #{govuk-from-breakpoint(desktop)} {
-    padding: 0;
+    padding: 0 15px 0 0;
     margin: 0;
   }
 
@@ -12,15 +12,22 @@
     }
 
     .govuk-grid-column-three-quarters-from-desktop {
-      height: calc(100vh - 70px - 55px);
+      height: calc(100vh - 70px - 55px - 50px);
 
       @media #{govuk-from-breakpoint(desktop)} {
         padding-left: 0;
+        padding-right: 0;
       }
     }
   }
 
   .app-map {
+    > .govuk-grid-row {
+      @media #{govuk-from-breakpoint(desktop)} {
+        border-top: 1px solid govuk-functional-colour(border);
+      }
+    }
+
     .app-map__error {
       position: absolute;
       margin: 5px 60px;
@@ -29,7 +36,7 @@
 
     .app-map__sidebar {
       overflow-y: auto;
-      max-height: calc(100vh - 70px - 55px);
+      max-height: calc(100vh - 70px - 55px - 50px);
 
       .govuk-tabs {
         @media #{govuk-from-breakpoint(desktop)} {

--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
@@ -78,6 +78,9 @@ context('Crime Version', () => {
 
       // And the device wearer details
       page.map.sidebar.shouldHaveDeviceWearer('deviceName', 'nomisId', '1', '1')
+
+      // And the backlink should have the default value
+      page.backLink.should('have.attr', 'href', '/proximity-alert')
     })
 
     it('should display a map showing crime version data with no matches', () => {
@@ -103,7 +106,7 @@ context('Crime Version', () => {
       })
 
       // When the user loads the page
-      cy.visit(`/proximity-alert/${crimeVersionId}`)
+      cy.visit(`/proximity-alert/${crimeVersionId}?returnTo=%2Fproximity-alert%3FcrimeReference%3DCHS`)
 
       const page = Page.verifyOnPage(CrimeVersionPage)
 
@@ -128,6 +131,9 @@ context('Crime Version', () => {
 
       // And no device wearer details
       page.map.sidebar.shouldNotHaveDeviceWearer()
+
+      // And the backlink should have the returnTo value
+      page.backLink.should('have.attr', 'href', '/proximity-alert?crimeReference=CHS')
     })
 
     it('should display a map showing crime version data with multiple matches', () => {

--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
@@ -433,7 +433,7 @@ context('Crime Version', () => {
 
           expect(centre[0]).to.be.closeTo(-2.528865717, 0.0000001)
           expect(centre[1]).to.be.closeTo(53.43157277, 0.0000001)
-          expect(map.getView().getZoom()).to.be.closeTo(18.1, 0.1)
+          expect(map.getView().getZoom()).to.be.closeTo(18, 0.2)
         })
       })
     })

--- a/integration_tests/e2e/proximityAlert/searchCrimes.page.cy.ts
+++ b/integration_tests/e2e/proximityAlert/searchCrimes.page.cy.ts
@@ -149,11 +149,19 @@ context('Search Crimes', () => {
       page.dataTable
         .cell(0, 1)
         .find('a')
-        .should('have.attr', 'href', '/proximity-alert/b06a517b-666b-4052-8bdc-b735e022c7c5')
+        .should(
+          'have.attr',
+          'href',
+          '/proximity-alert/b06a517b-666b-4052-8bdc-b735e022c7c5?returnTo=%2Fproximity-alert%3FcrimeReference%3Dabc',
+        )
       page.dataTable
         .cell(1, 1)
         .find('a')
-        .should('have.attr', 'href', '/proximity-alert/fe1592c0-dc78-46c3-88cd-144f1f1ec022')
+        .should(
+          'have.attr',
+          'href',
+          '/proximity-alert/fe1592c0-dc78-46c3-88cd-144f1f1ec022?returnTo=%2Fproximity-alert%3FcrimeReference%3Dabc',
+        )
     })
 
     it('should show allow the user to navigate to other pages in the result set', () => {

--- a/integration_tests/pages/proximityAlert/crimeVersion.ts
+++ b/integration_tests/pages/proximityAlert/crimeVersion.ts
@@ -1,9 +1,14 @@
 import AppPage from '../appPage'
 import MapComponent from '../components/mapComponent'
+import { PageElement } from '../page'
 
 export default class CrimeVersionPage extends AppPage {
   constructor() {
     super(null)
+  }
+
+  get backLink(): PageElement {
+    return cy.get('a.govuk-back-link')
   }
 
   get map(): MapComponent {

--- a/server/controllers/policeData/ingestionAttempt.test.ts
+++ b/server/controllers/policeData/ingestionAttempt.test.ts
@@ -74,7 +74,6 @@ describe('PoliceDataIngestionAttemptController', () => {
       // Then
       expect(mockRestClient.getIngestionAttempt).toHaveBeenCalledWith(expectedAuthOptions, ingestionAttemptId)
       expect(res.render).toHaveBeenCalledWith('pages/policeData/ingestionAttempt', {
-        backLink: '/police-data/dashboard',
         ingestionAttempt: {
           batchId: 'CMB20250710',
           createdAt: '2026-03-17T11:33:38.483121',
@@ -172,7 +171,6 @@ describe('PoliceDataIngestionAttemptController', () => {
       // Then
       expect(mockRestClient.getIngestionAttempt).toHaveBeenCalledWith(expectedAuthOptions, ingestionAttemptId)
       expect(res.render).toHaveBeenCalledWith('pages/policeData/ingestionAttempt', {
-        backLink: '/police-data/dashboard',
         ingestionAttempt: {
           batchId: 'CMB20250710',
           createdAt: '2026-03-17T11:33:38.483121',
@@ -284,7 +282,6 @@ describe('PoliceDataIngestionAttemptController', () => {
       // Then
       expect(mockRestClient.getIngestionAttempt).toHaveBeenCalledWith(expectedAuthOptions, ingestionAttemptId)
       expect(res.render).toHaveBeenCalledWith('pages/policeData/ingestionAttempt', {
-        backLink: '/police-data/dashboard',
         ingestionAttempt: {
           batchId: 'CMB20250710',
           createdAt: '2026-03-17T11:33:38.483121',
@@ -395,7 +392,6 @@ describe('PoliceDataIngestionAttemptController', () => {
       // Then
       expect(mockRestClient.getIngestionAttempt).toHaveBeenCalledWith(expectedAuthOptions, ingestionAttemptId)
       expect(res.render).toHaveBeenCalledWith('pages/policeData/ingestionAttempt', {
-        backLink: '/police-data/dashboard',
         ingestionAttempt: {
           batchId: 'Failed',
           createdAt: '2026-03-17T11:33:38.483049',
@@ -498,7 +494,6 @@ describe('PoliceDataIngestionAttemptController', () => {
       // Then
       expect(mockRestClient.getIngestionAttempt).toHaveBeenCalledWith(expectedAuthOptions, ingestionAttemptId)
       expect(res.render).toHaveBeenCalledWith('pages/policeData/ingestionAttempt', {
-        backLink: '/police-data/dashboard',
         ingestionAttempt: {
           batchId: 'Failed',
           createdAt: '2026-03-17T11:33:38.483028',
@@ -567,49 +562,6 @@ describe('PoliceDataIngestionAttemptController', () => {
           ],
         },
       })
-    })
-
-    it('should parse a returnTo link from query parameters', async () => {
-      // Given
-      const ingestionAttemptId = '64d41bd9-5450-4bbb-89d4-42ba75659f49'
-      const req = createMockRequest({
-        params: { ingestionAttemptId },
-        query: { returnTo: '%2Fpolice-data%2Fdashboard%3FbatchId%3DS' },
-      })
-      const res = createMockResponse()
-      const next = jest.fn()
-      const policeDataService = new PoliceDataService(mockRestClient)
-      const controller = new PoliceDataIngestionAttemptController(policeDataService)
-
-      mockRestClient.getIngestionAttempt.mockResolvedValue({
-        data: {
-          ingestionAttemptId: '64d41bd9-5450-4bbb-89d4-42ba75659f49',
-          ingestionStatus: 'SUCCESSFUL',
-          policeForceArea: 'CUMBRIA',
-          crimeBatchId: '4aba17e8-3cc1-4b3d-8be4-b7e5c0d6b15d',
-          batchId: 'CMB20250710',
-          matches: null,
-          createdAt: '2026-03-17T11:33:38.483121',
-          fileName: '20260101000000.csv',
-          submitted: 2,
-          successful: 2,
-          failed: 0,
-          crimesByCrimeType: [{ crimeType: 'BIAD', submitted: 2, failed: 0, successful: 2 }],
-          validationErrors: [],
-        },
-      })
-
-      // When
-      await controller.view(req, res, next)
-
-      // Then
-      expect(mockRestClient.getIngestionAttempt).toHaveBeenCalledWith(expectedAuthOptions, ingestionAttemptId)
-      expect(res.render).toHaveBeenCalledWith(
-        'pages/policeData/ingestionAttempt',
-        expect.objectContaining({
-          backLink: '%2Fpolice-data%2Fdashboard%3FbatchId%3DS',
-        }),
-      )
     })
   })
 

--- a/server/controllers/policeData/ingestionAttempt.ts
+++ b/server/controllers/policeData/ingestionAttempt.ts
@@ -1,7 +1,6 @@
 import { RequestHandler } from 'express'
 import PoliceDataService from '../../services/policeDataService'
 import presentIngestionAttempt from '../../presenters/ingestionAttempt'
-import { policeDataIngestionAttemptQuerySchema } from '../../schemas/policeData/ingestionAttempt'
 import generateValidationErrorsExport from '../../presenters/reports/validationErrors'
 
 export default class PoliceDataIngestionAttemptController {
@@ -10,12 +9,10 @@ export default class PoliceDataIngestionAttemptController {
   view: RequestHandler = async (req, res) => {
     const { username } = res.locals.user
     const { ingestionAttemptId } = req.params
-    const { returnTo } = policeDataIngestionAttemptQuerySchema.parse(req.query)
     const ingestionAttempt = await this.policeDataService.getIngestionAttempt(username, ingestionAttemptId)
 
     res.render('pages/policeData/ingestionAttempt', {
       ingestionAttempt: presentIngestionAttempt(ingestionAttempt),
-      backLink: returnTo,
     })
   }
 

--- a/server/middleware/populateBackLink.test.ts
+++ b/server/middleware/populateBackLink.test.ts
@@ -1,0 +1,39 @@
+import createMockRequest from '../testutils/createMockRequest'
+import createMockResponse from '../testutils/createMockResponse'
+import populateBackLink from './populateBackLink'
+
+describe('populateBackLink', () => {
+  it('should populate res.locals with the default value when returnTo query param is missing', () => {
+    // Given
+    const req = createMockRequest()
+    const res = createMockResponse()
+    const next = jest.fn()
+    const middleware = populateBackLink('/default-value')
+
+    // When
+    middleware(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(res.locals.backLink).toEqual('/default-value')
+  })
+
+  it('should populate res.locals with the returnTo query param value when present', () => {
+    // Given
+    const req = createMockRequest({
+      query: {
+        returnTo: '/return-to',
+      },
+    })
+    const res = createMockResponse()
+    const next = jest.fn()
+    const middleware = populateBackLink('/default-value')
+
+    // When
+    middleware(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(res.locals.backLink).toEqual('/return-to')
+  })
+})

--- a/server/middleware/populateBackLink.ts
+++ b/server/middleware/populateBackLink.ts
@@ -1,0 +1,20 @@
+import { RequestHandler } from 'express'
+import { z } from 'zod/v4'
+
+const populateBackLink = (defaultValue: string): RequestHandler => {
+  const schema = z.object({
+    returnTo: z.string().default(defaultValue),
+  })
+
+  return (req, res, next) => {
+    const result = schema.safeParse(req.query)
+
+    if (result.success) {
+      res.locals.backLink = result.data.returnTo
+    }
+
+    next()
+  }
+}
+
+export default populateBackLink

--- a/server/routes/police-data.ts
+++ b/server/routes/police-data.ts
@@ -3,6 +3,7 @@ import type { Services } from '../services'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import PoliceDataDashboardController from '../controllers/policeData/dashboard'
 import PoliceDataIngestionAttemptController from '../controllers/policeData/ingestionAttempt'
+import populateBackLink from '../middleware/populateBackLink'
 
 const policeDataRoutes = ({ crimeMatchingResultsService, policeDataService }: Services): Router => {
   const router = Router()
@@ -16,7 +17,11 @@ const policeDataRoutes = ({ crimeMatchingResultsService, policeDataService }: Se
   router.post('/dashboard', asyncMiddleware(policeDataDashboardController.search))
   router.get('/dashboard/export', asyncMiddleware(policeDataDashboardController.export))
 
-  router.get('/ingestion-attempts/:ingestionAttemptId', asyncMiddleware(policeDataIngestionAttemptController.view))
+  router.get(
+    '/ingestion-attempts/:ingestionAttemptId',
+    populateBackLink('/police-data/dashboard'),
+    asyncMiddleware(policeDataIngestionAttemptController.view),
+  )
   router.get(
     '/ingestion-attempts/:ingestionAttemptId/export',
     asyncMiddleware(policeDataIngestionAttemptController.export),

--- a/server/routes/proximity-alert.ts
+++ b/server/routes/proximity-alert.ts
@@ -5,6 +5,7 @@ import CrimeSearchController from '../controllers/proximityAlert/crimeSearch'
 import CrimeVersionController from '../controllers/proximityAlert/crimeVersion'
 import MapImageRendererService from '../services/proximityAlert/mapImageRendererService'
 import ProximityAlertReportDocxService from '../services/proximityAlert/proximityAlertReportDocxService'
+import populateBackLink from '../middleware/populateBackLink'
 
 const proximityAlertRoutes = ({ crimeService, playwrightBrowserService }: Services): Router => {
   const router = Router()
@@ -22,7 +23,7 @@ const proximityAlertRoutes = ({ crimeService, playwrightBrowserService }: Servic
   router.get('/', asyncMiddleware(crimeSearchController.view))
   router.post('/', asyncMiddleware(crimeSearchController.search))
 
-  router.get('/:crimeVersionId', asyncMiddleware(crimeVersionController.view))
+  router.get('/:crimeVersionId', populateBackLink('/proximity-alert'), asyncMiddleware(crimeVersionController.view))
 
   // Ensure that when signing in, the redirected route doesn't land the user on the export action route
   router.get('/:crimeVersionId/export-proximity-alert', (req: Request<{ crimeVersionId: string }>, res: Response) => {

--- a/server/schemas/policeData/ingestionAttempt.ts
+++ b/server/schemas/policeData/ingestionAttempt.ts
@@ -1,9 +1,5 @@
 import { z } from 'zod/v4'
 
-const policeDataIngestionAttemptQuerySchema = z.object({
-  returnTo: z.string().default('/police-data/dashboard'),
-})
-
 const getIngestionAttemptDtoSchema = z.object({
   data: z.object({
     ingestionAttemptId: z.string(),
@@ -34,4 +30,4 @@ const getIngestionAttemptDtoSchema = z.object({
   }),
 })
 
-export { getIngestionAttemptDtoSchema, policeDataIngestionAttemptQuerySchema }
+export default getIngestionAttemptDtoSchema

--- a/server/services/policeDataService.ts
+++ b/server/services/policeDataService.ts
@@ -7,7 +7,7 @@ import { parseDateTimeFromComponents } from '../utils/date'
 import { getIngestionAttemptSummariesDtoSchema } from '../schemas/policeData/dashboard'
 import Result from '../types/result'
 import IngestionAttempt from '../types/ingestionAttempt'
-import { getIngestionAttemptDtoSchema } from '../schemas/policeData/ingestionAttempt'
+import getIngestionAttemptDtoSchema from '../schemas/policeData/ingestionAttempt'
 
 class PoliceDataService {
   constructor(private readonly crimeMatchingApiClient: CrimeMatchingClient) {}

--- a/server/views/pages/proximityAlert/crimeSearch.njk
+++ b/server/views/pages/proximityAlert/crimeSearch.njk
@@ -13,7 +13,11 @@
 
 {% for crime in crimes %}
   {% set link %}
-    <a href="/proximity-alert/{{ crime.crimeVersionId }}"> {{ crime.crimeReference }} </a>
+    <a
+      href="/proximity-alert/{{ crime.crimeVersionId }}?returnTo={{ ('/proximity-alert?' ~ paginationHrefPrefix) | urlencode }}"
+    >
+      {{ crime.crimeReference }}
+    </a>
   {% endset %}
 
 

--- a/server/views/pages/proximityAlert/crimeVersion.njk
+++ b/server/views/pages/proximityAlert/crimeVersion.njk
@@ -1,5 +1,6 @@
 {% extends "../../partials/layout.njk" %}
 {% from "../../components/map/macro.njk" import appMap %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
@@ -12,6 +13,17 @@
 {% set reportsHtml %}
   {%- include "./partials/reports.njk" -%}
 {% endset %}
+
+{% block beforeContent %}
+  <div class="govuk-!-static-padding-left-4">
+    {{
+      govukBackLink({
+        text: "Back",
+        href: backLink
+      })
+    }}
+  </div>
+{% endblock %}
 
 
 {% set analysisHtml %}


### PR DESCRIPTION
- Adds the back button the proximity alert view and adjusts the size of the map to still fit the full height of the screen (the map is now smaller by 50px).
- Populates the back button link using a new middleware that will try to find `returnTo` query parameter and use that to populate the link. The middleware can be constructed with a default value that will be used if the query parameter is missing.
- Refactored the `PoliceDataIngestionAttemptController` controller to use the middleware which removes the `backLink` property from the data sent to the view engine from the controller.
- The functionality is still validated through integration tests for both `/police-data/ingestion-attempts/:ingestionAttemptId` and `/proximity-alert/:crimeVersionId`. 

> N.B. I've had to increase the allowed range of zoom values for the "view on map" test as its a bit flaky...