### PR TITLE
Show a warning if matching has not run or did not match any devices

### DIFF
--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
@@ -114,7 +114,7 @@ context('Crime Version', () => {
 
       // Then the page should display the map and sidebar components
       page.map.shouldExist()
-      page.map.shouldHaveAlert('warning', 'No devices were matched to this crime.')
+      page.map.shouldHaveAlert('information', 'No devices were matched to this crime.')
       page.map.sidebar.shouldExist()
       page.map.sidebar.shouldHaveProximityTabs()
       page.map.sidebar.reportsTab.shouldBeActive()

--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.cy.ts
@@ -83,7 +83,63 @@ context('Crime Version', () => {
       page.backLink.should('have.attr', 'href', '/proximity-alert')
     })
 
-    it('should display a map showing crime version data with no matches', () => {
+    it('should display a map showing crime version data when no devices were matched to the crime', () => {
+      // Given an API response containing a crime version with no matches
+      cy.stubGetCrimeVersion({
+        status: 200,
+        crimeVersionId: '64d41bd9-5450-4bbb-89d4-42ba75659f49',
+        response: {
+          data: {
+            crimeVersionId,
+            crimeReference: 'crimeRef',
+            crimeTypeDescription: 'Aggravated Burglary',
+            crimeTypeId: 'AB',
+            crimeDateTimeFrom: '2025-01-01T00:00:00Z',
+            crimeDateTimeTo: '2025-01-01T01:00:00Z',
+            crimeText: 'crimeText',
+            longitude: 0,
+            latitude: 0,
+            versionLabel: 'Latest Version',
+            matching: {
+              deviceWearers: [],
+            },
+          },
+        },
+      })
+
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}?returnTo=%2Fproximity-alert%3FcrimeReference%3DCHS`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // Then the page should display the map and sidebar components
+      page.map.shouldExist()
+      page.map.shouldHaveAlert('warning', 'No devices were matched to this crime.')
+      page.map.sidebar.shouldExist()
+      page.map.sidebar.shouldHaveProximityTabs()
+      page.map.sidebar.reportsTab.shouldBeActive()
+      page.map.sidebar.analysisTab.shouldNotBeActive()
+      page.map.sidebar.shouldHaveProximityControls()
+
+      // And the crime version details
+      page.map.sidebar.shouldHaveVersionLabel('Latest Version')
+      page.map.sidebar.crimeToggle.shouldBeChecked('device-wearer-toggle')
+      page.map.sidebar.crimeToggle.shouldHaveText('crimeRefAggravated Burglary')
+
+      page.map.sidebar.crimeVersionSummaryList.shouldExist()
+      page.map.sidebar.crimeVersionSummaryList.shouldHaveItem('From:', '01/01/2025 00:00')
+      page.map.sidebar.crimeVersionSummaryList.shouldHaveItem('To:', '01/01/2025 01:00')
+      page.map.sidebar.crimeVersionSummaryList.shouldHaveItem('Desc:', 'crimeText')
+
+      // And no device wearer details
+      page.map.sidebar.shouldNotHaveDeviceWearer()
+      page.map.sidebar.exportProximityAlertForm.shouldNotExist()
+
+      // And the backlink should have the returnTo value
+      page.backLink.should('have.attr', 'href', '/proximity-alert?crimeReference=CHS')
+    })
+
+    it('should display a map showing crime version data when matching has not happened yet', () => {
       // Given an API response containing a crime version with no matches
       cy.stubGetCrimeVersion({
         status: 200,
@@ -112,7 +168,7 @@ context('Crime Version', () => {
 
       // Then the page should display the map and sidebar components
       page.map.shouldExist()
-      page.map.shouldNotHaveAlerts()
+      page.map.shouldHaveAlert('warning', 'Matching for this crime has not occurred yet.')
       page.map.sidebar.shouldExist()
       page.map.sidebar.shouldHaveProximityTabs()
       page.map.sidebar.reportsTab.shouldBeActive()
@@ -131,6 +187,7 @@ context('Crime Version', () => {
 
       // And no device wearer details
       page.map.sidebar.shouldNotHaveDeviceWearer()
+      page.map.sidebar.exportProximityAlertForm.shouldNotExist()
 
       // And the backlink should have the returnTo value
       page.backLink.should('have.attr', 'href', '/proximity-alert?crimeReference=CHS')

--- a/integration_tests/pages/components/formComponent.ts
+++ b/integration_tests/pages/components/formComponent.ts
@@ -1,23 +1,21 @@
-import { v4 as uuidv4 } from 'uuid'
-
 import { PageElement } from '../page'
 
 export default abstract class FormComponent {
-  protected elementCacheId: string = uuidv4()
-
-  constructor(id: string) {
-    cy.get(`form#${id}`, { log: false }).as(this.elementCacheId)
-  }
+  constructor(private readonly id: string) {}
 
   // PROPERTIES
 
   protected get form(): PageElement {
-    return cy.get(`@${this.elementCacheId}`, { log: false })
+    return cy.get(`form#${this.id}`, { log: false })
   }
 
   // HELPERS
 
   checkHasForm(): void {
     this.form.should('exist')
+  }
+
+  shouldNotExist(): void {
+    this.form.should('not.exist')
   }
 }

--- a/integration_tests/pages/components/forms/exportProximityAlertForm.ts
+++ b/integration_tests/pages/components/forms/exportProximityAlertForm.ts
@@ -1,0 +1,29 @@
+import { PageElement } from '../../page'
+import FormComponent from '../formComponent'
+import FormRadiosComponent from '../formRadiosComponent'
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+type ExportProximityAlertFormDate = {}
+
+class ExportProximityAlertFormComponent extends FormComponent {
+  constructor() {
+    super('exportProximityAlertForm')
+  }
+
+  // FIELDS
+
+  get reportTypeField(): FormRadiosComponent {
+    return new FormRadiosComponent(this.form, 'Export trail data')
+  }
+
+  get exportButton(): PageElement {
+    return this.form.contains('button', 'Export proximity alert')
+  }
+
+  // HELPERS
+
+  // eslint-disable-next-line no-empty-function, @typescript-eslint/no-unused-vars
+  fillInWith(data: ExportProximityAlertFormDate) {}
+}
+
+export default ExportProximityAlertFormComponent

--- a/integration_tests/pages/components/forms/exportProximityAlertForm.ts
+++ b/integration_tests/pages/components/forms/exportProximityAlertForm.ts
@@ -1,6 +1,5 @@
 import { PageElement } from '../../page'
 import FormComponent from '../formComponent'
-import FormRadiosComponent from '../formRadiosComponent'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type ExportProximityAlertFormDate = {}
@@ -11,10 +10,6 @@ class ExportProximityAlertFormComponent extends FormComponent {
   }
 
   // FIELDS
-
-  get reportTypeField(): FormRadiosComponent {
-    return new FormRadiosComponent(this.form, 'Export trail data')
-  }
 
   get exportButton(): PageElement {
     return this.form.contains('button', 'Export proximity alert')

--- a/integration_tests/pages/components/mapSidebarComponent.ts
+++ b/integration_tests/pages/components/mapSidebarComponent.ts
@@ -5,6 +5,7 @@ import SearchDeviceActivationPositionsFormComponent from './forms/searchDeviceAc
 import ExportLocationDataFormComponent from './forms/exportLocationDataForm'
 import FormCheckboxesComponent from './formCheckboxesComponent'
 import SummaryListComponent from './summaryListComponent'
+import ExportProximityAlertFormComponent from './forms/exportProximityAlertForm'
 
 export default class MapSidebarComponent {
   private elementCacheId: string = uuidv4()
@@ -57,6 +58,10 @@ export default class MapSidebarComponent {
 
   get exportForm(): ExportLocationDataFormComponent {
     return new ExportLocationDataFormComponent()
+  }
+
+  get exportProximityAlertForm(): ExportProximityAlertFormComponent {
+    return new ExportProximityAlertFormComponent()
   }
 
   // HELPERS

--- a/server/views/pages/proximityAlert/partials/reports.njk
+++ b/server/views/pages/proximityAlert/partials/reports.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "moj/components/alert/macro.njk" import mojAlert %}
 
 {{
   govukTag({
@@ -73,97 +74,113 @@
   })
 }}
 
-<form id="exportProximityAlertForm" method="post" action="{{ exportProximityAlertForm.url }}">
-  <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-  <input type="hidden" id="capturedMapState" name="capturedMapState" value="" />
-
-  <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m" />
-  {% for deviceWearer in crimeVersion.matching.deviceWearers %}
-
-    {{
-      govukSummaryList({
-        classes: "govuk-summary-list--no-border device-wearer-summary-list govuk-!-margin-bottom-0",
-        rows: [
-          {
-            key: {
-              classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
-              text: "Name:"
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m" />
+{% if not crimeVersion.matching %}
+  {{
+    mojAlert({
+      variant: "warning",
+      title: "Matching for this crime has not occurred yet.",
+      showTitleAsHeading: false,
+      dismissible: false
+    })
+  }}
+{% elif crimeVersion.matching.deviceWearers | length == 0 %}
+  {{
+    mojAlert({
+      variant: "warning",
+      title: "No devices were matched to this crime.",
+      showTitleAsHeading: false,
+      dismissible: false
+    })
+  }}
+{% else %}
+  <form id="exportProximityAlertForm" method="post" action="{{ exportProximityAlertForm.url }}">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+    <input type="hidden" id="capturedMapState" name="capturedMapState" value="" />
+    {% for deviceWearer in crimeVersion.matching.deviceWearers %}
+      {{
+        govukSummaryList({
+          classes: "govuk-summary-list--no-border device-wearer-summary-list govuk-!-margin-bottom-0",
+          rows: [
+            {
+              key: {
+                classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
+                text: "Name:"
+              },
+              value: {
+                classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
+                text: deviceWearer.name
+              }
             },
-            value: {
-              classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
-              text: deviceWearer.name
-            }
-          },
-          {
-            key: {
-              classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
-              text: "NOMIS ID:"
+            {
+              key: {
+                classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
+                text: "NOMIS ID:"
+              },
+              value: {
+                classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
+                text: deviceWearer.nomisId
+              }
             },
-            value: {
-              classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
-              text: deviceWearer.nomisId
-            }
-          },
-          {
-            key: {
-              classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
-              text: "ID:"
+            {
+              key: {
+                classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
+                text: "ID:"
+              },
+              value: {
+                classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
+                text: deviceWearer.deviceId
+              }
             },
-            value: {
-              classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
-              text: deviceWearer.deviceId
+            {
+              key: {
+                classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
+                text: "Count:"
+              },
+              value: {
+                classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
+                text: deviceWearer.positions.length
+              }
             }
+          ]
+        })
+      }}
+
+      {{
+        govukCheckboxes({
+          id: 'device-wearer-toggle-' + deviceWearer.deviceId,
+          classes: "govuk-checkboxes--small",
+          name: "device-wearer-toggle-" + deviceWearer.deviceId,
+          attributes: {
+            "data-module": 'map-layer-visibility-toggle'
           },
-          {
-            key: {
-              classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
-              text: "Count:"
+          items: [
+            {
+              id: 'device-wearer-tracks-' + deviceWearer.deviceId,
+              text: "Show tracks",
+              name: 'device-wearer-tracks',
+              value: 'device-wearer-tracks-' + deviceWearer.deviceId
             },
-            value: {
-              classes: "govuk-!-static-padding-top-0 govuk-!-static-padding-bottom-1",
-              text: deviceWearer.positions.length
+            {
+              id: 'device-wearer-' + deviceWearer.deviceId,
+              value: 'device-wearer-' + deviceWearer.deviceId,
+              text: "Include",
+              name: 'device-wearer-toggle',
+              checked: true
             }
-          }
-        ]
-      })
-    }}
-
-    {{
-      govukCheckboxes({
-        id: 'device-wearer-toggle-' + deviceWearer.deviceId,
-        classes: "govuk-checkboxes--small",
-        name: "device-wearer-toggle-" + deviceWearer.deviceId,
-        attributes: {
-          "data-module": 'map-layer-visibility-toggle'
-        },
-        items: [
-          {
-            id: 'device-wearer-tracks-' + deviceWearer.deviceId,
-            text: "Show tracks",
-            name: 'device-wearer-tracks',
-            value: 'device-wearer-tracks-' + deviceWearer.deviceId
-          },
-          {
-            id: 'device-wearer-' + deviceWearer.deviceId,
-            value: 'device-wearer-' + deviceWearer.deviceId,
-            text: "Include",
-            name: 'device-wearer-toggle',
-            checked: true
-          }
-        ]
-      })
-    }}
-
-    {% if not loop.last %}
-      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m" />
-    {% endif %}
-  {% endfor %}
-
-  <div class="govuk-!-margin-top-4">
-    {{
-      govukButton({
-        text: "Export proximity alert"
-      })
-    }}
-  </div>
-</form>
+          ]
+        })
+      }}
+      {% if not loop.last %}
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m" />
+      {% endif %}
+    {% endfor %}
+    <div class="govuk-!-margin-top-4">
+      {{
+        govukButton({
+          text: "Export proximity alert"
+        })
+      }}
+    </div>
+  </form>
+{% endif %}

--- a/server/views/pages/proximityAlert/partials/reports.njk
+++ b/server/views/pages/proximityAlert/partials/reports.njk
@@ -87,7 +87,7 @@
 {% elif crimeVersion.matching.deviceWearers | length == 0 %}
   {{
     mojAlert({
-      variant: "warning",
+      variant: "information",
       title: "No devices were matched to this crime.",
       showTitleAsHeading: false,
       dismissible: false


### PR DESCRIPTION
This isn't part of the designs but we need to indicate to the user why they're not seeing devices for the crime they're viewing if matching hasn't happened yet or matching didn't produce any matched device wearers.

There are a couple of `eslint-disable-next-line` comments. This is because the rest of this component will probably be set up by the work Patrick is doing.

The base `FormComponent` has been updated to ensure we can test that forms are absent. For example, the Hub do not produce proximity alerts for crimes that have no matches, so the export proximity alert form should not be present. This is to avoid accidental form submissions (e.g. pressing enter on the keyboard).

## Demo

No matching:
<img width="2541" height="1200" alt="Screenshot 2026-04-16 at 16 23 52" src="https://github.com/user-attachments/assets/605a4c67-c231-4862-837b-6a1eed956ddf" />

No matched device wearers:
<img width="2542" height="1195" alt="Screenshot 2026-04-16 at 16 39 54" src="https://github.com/user-attachments/assets/7d6f9da6-23d0-4636-b241-6ea728d8cd0c" />


