### PR TITLE
Acr 665 config driven map

### DIFF
--- a/assets/js/views/proximity-alert/crimeVersion.ts
+++ b/assets/js/views/proximity-alert/crimeVersion.ts
@@ -84,11 +84,11 @@ const isHeadlessCapture = (): boolean => {
 }
 
 // Reads selected device IDs from the headless export URL and returns them as a numeric set.
-const getHeadlessSelectedDeviceIds = (): Set<number> | undefined => {
+const getHeadlessSelectedDeviceIds = (): Set<number> => {
   const params = new URLSearchParams(window.location.search)
   const selectedDeviceIds = params.get('selectedDeviceIds')
 
-  if (!selectedDeviceIds) return undefined
+  if (!selectedDeviceIds) return new Set()
 
   const parsedDeviceIds = selectedDeviceIds
     .split(',')
@@ -101,7 +101,6 @@ const getHeadlessSelectedDeviceIds = (): Set<number> | undefined => {
 // Filters map data to include only selected device wearers when running in headless export mode.
 const filterMapDataForHeadlessExport = (data: MapData): MapData => {
   const selectedDeviceIds = getHeadlessSelectedDeviceIds()
-  if (!selectedDeviceIds) return data
 
   return {
     ...data,
@@ -133,15 +132,15 @@ const readJsonFromScript = <T>(id: string): T | undefined => {
 
 // Initialises the shared proximity alert map, then delegates user or headless export behaviour.
 const initialiseProximityAlertView = async () => {
-  const rawData = readJsonFromScript<MapData>('map-data')
+  const allMapData = readJsonFromScript<MapData>('map-data')
 
-  if (!rawData) {
+  if (!allMapData) {
     return
   }
 
   const emMap = queryElement(document, 'em-map') as EmMap
   const isHeadless = isHeadlessCapture()
-  const data = isHeadless ? filterMapDataForHeadlessExport(rawData) : rawData
+  const data = isHeadless ? filterMapDataForHeadlessExport(allMapData) : allMapData
 
   await new Promise<void>(resolve => {
     emMap.addEventListener('map:ready', () => resolve(), { once: true })
@@ -154,18 +153,22 @@ const initialiseProximityAlertView = async () => {
   const allDeviceIds: number[] = []
 
   if (data.matching) {
-    let colourIndex = 0
+    const colourByDeviceId = new Map<number, string>()
+
+    allMapData.matching?.deviceWearers.forEach((deviceWearer, index) => {
+      colourByDeviceId.set(deviceWearer.deviceId, palette[index % palette.length])
+    })
+
     for (const deviceWearer of data.matching.deviceWearers) {
       emMap.addLayerGroup(
         new DeviceWearerLayer(
           deviceWearer.deviceId,
           data.crimePosition,
           deviceWearer.positions,
-          palette[colourIndex % palette.length],
+          colourByDeviceId.get(deviceWearer.deviceId) ?? palette[0],
         ),
       )
       allDeviceIds.push(deviceWearer.deviceId)
-      colourIndex += 1
     }
   }
 

--- a/assets/js/views/proximity-alert/crimeVersion.ts
+++ b/assets/js/views/proximity-alert/crimeVersion.ts
@@ -1,12 +1,13 @@
 import { EmMap, Position } from '@ministryofjustice/hmpps-electronic-monitoring-components/map'
 import { fromLonLat } from 'ol/proj'
 import type { Coordinate } from 'ol/coordinate'
-import { queryElement, queryElementAll } from '../../utils/utils'
+import { queryElement } from '../../utils/utils'
 import CrimeLayer from './layers/crime'
 import DeviceWearerLayer from './layers/deviceWearer'
-import initialiseProximityAlertForm from '../../forms/proximity-alert'
+import initialiseProximityAlertExportView from './mapExport'
+import initialiseProximityAlertUserView from './mapUserView'
 
-type CapturedMapState = {
+export type CapturedMapState = {
   mapWidthPx: number
   mapHeightPx: number
   devicePixelRatio: number
@@ -17,19 +18,7 @@ type CapturedMapState = {
   }
 }
 
-type PresetParam = 'overview-user-view' | 'overview-fitted' | 'wearer-overview' | 'wearer-detail'
-
-type ExportMapRenderConfig = {
-  selectedDeviceIds?: number[]
-  focusedDeviceId?: number
-  showTracks: boolean
-  showConfidenceCircles: boolean
-  showLocationNumbering: boolean
-  fitToSelectedPositions: boolean
-  fitToFocusedDevicePositions: boolean
-}
-
-type MapData = {
+export type MapData = {
   crimePosition: Position
   matching?: {
     deviceWearers: Array<{
@@ -37,11 +26,6 @@ type MapData = {
       positions: Array<Position>
     }>
   }
-}
-
-type MapImagesApi = {
-  applyPreset: (preset: PresetParam, deviceId?: string) => void
-  applyCapturedMapState: (state: CapturedMapState) => void
 }
 
 const palette = [
@@ -79,71 +63,6 @@ const setCrimeDefaultView = (emMap: EmMap, centre: Coordinate) => {
   map.getView().setZoom(16.5)
 }
 
-const dispatchCheckboxChange = (checkbox: HTMLInputElement) => {
-  checkbox.dispatchEvent(new Event('change', { bubbles: true }))
-}
-
-const applyCheckboxLayerState = () => {
-  const selectors = [
-    'input[type="checkbox"][name="device-wearer-toggle"]',
-    'input[type="checkbox"][name="device-wearer-tracks"]',
-    'input[type="checkbox"][name="analysis-toggles"]',
-  ]
-
-  for (const selector of selectors) {
-    const checkboxes = queryElementAll(document, selector, HTMLInputElement)
-
-    checkboxes.forEach(checkbox => {
-      dispatchCheckboxChange(checkbox)
-    })
-  }
-}
-
-// Type guard to validate the structure of the captured map state
-const isValidCapturedMapState = (parsedMapState: unknown): parsedMapState is CapturedMapState => {
-  if (!parsedMapState || typeof parsedMapState !== 'object') return false
-
-  const parsedState = parsedMapState as {
-    mapWidthPx?: unknown
-    mapHeightPx?: unknown
-    devicePixelRatio?: unknown
-    view?: {
-      center?: unknown
-      resolution?: unknown
-      rotation?: unknown
-    }
-  }
-
-  return (
-    typeof parsedState.mapWidthPx === 'number' &&
-    typeof parsedState.mapHeightPx === 'number' &&
-    typeof parsedState.devicePixelRatio === 'number' &&
-    !!parsedState.view &&
-    Array.isArray(parsedState.view.center) &&
-    parsedState.view.center.length === 2 &&
-    typeof parsedState.view.center[0] === 'number' &&
-    typeof parsedState.view.center[1] === 'number' &&
-    typeof parsedState.view.resolution === 'number' &&
-    typeof parsedState.view.rotation === 'number'
-  )
-}
-
-// Attempt to read captured map state from hidden input field
-const getCapturedMapState = (): CapturedMapState | undefined => {
-  const mapStateInput = document.querySelector<HTMLInputElement>('#capturedMapState')
-  if (!mapStateInput) return undefined
-
-  const mapStateValue = mapStateInput.value.trim()
-  if (!mapStateValue) return undefined
-
-  try {
-    const parsedMapState: unknown = JSON.parse(mapStateValue)
-    return isValidCapturedMapState(parsedMapState) ? parsedMapState : undefined
-  } catch {
-    return undefined
-  }
-}
-
 // Apply captured map state to the map view
 const applyCapturedMapState = (emMap: EmMap, mapState: CapturedMapState) => {
   const map = emMap.olMapInstance
@@ -158,69 +77,43 @@ const applyCapturedMapState = (emMap: EmMap, mapState: CapturedMapState) => {
   map.renderSync()
 }
 
+// Determines if the page is running in headless export mode.
 const isHeadlessCapture = (): boolean => {
   const params = new URLSearchParams(window.location.search)
   return params.get('headless') === 'true'
 }
 
-const getHeadlessMapSizeFromUrl = (): { widthPx: number; heightPx: number } | null => {
+// Reads selected device IDs from the headless export URL and returns them as a numeric set.
+const getHeadlessSelectedDeviceIds = (): Set<number> | undefined => {
   const params = new URLSearchParams(window.location.search)
-  const mapWidthPx = params.get('mapWidthPx')
-  const mapHeightPx = params.get('mapHeightPx')
+  const selectedDeviceIds = params.get('selectedDeviceIds')
 
-  if (!mapWidthPx || !mapHeightPx) return null
+  if (!selectedDeviceIds) return undefined
 
-  const widthPx = Number(mapWidthPx)
-  const heightPx = Number(mapHeightPx)
-
-  if (!Number.isFinite(widthPx) || !Number.isFinite(heightPx) || widthPx <= 0 || heightPx <= 0) {
-    return null
-  }
-
-  return { widthPx, heightPx }
-}
-
-const getSelectedDeviceIdsFromUrl = (): number[] | undefined => {
-  const params = new URLSearchParams(window.location.search)
-  const deviceIdsParamValues = params.get('deviceIds')
-
-  if (!deviceIdsParamValues) return undefined
-
-  const deviceIds = deviceIdsParamValues
+  const parsedDeviceIds = selectedDeviceIds
     .split(',')
-    .map(value => Number(value.trim()))
-    .filter(value => Number.isFinite(value))
+    .map(deviceId => Number(deviceId))
+    .filter(deviceId => Number.isFinite(deviceId))
 
-  return deviceIds.length > 0 ? deviceIds : undefined
+  return new Set(parsedDeviceIds)
 }
 
-// Headless-only UI tweaks for export screenshots:
-const applyHeadlessUiTweaks = (emMap: EmMap) => {
-  const root = emMap.shadowRoot
-  if (!root) return
+// Filters map data to include only selected device wearers when running in headless export mode.
+const filterMapDataForHeadlessExport = (data: MapData): MapData => {
+  const selectedDeviceIds = getHeadlessSelectedDeviceIds()
+  if (!selectedDeviceIds) return data
 
-  const controls = root.querySelectorAll<HTMLElement>('.ol-control, .ol-attribution')
-  controls.forEach(controlEl => {
-    const el = controlEl
-    el.style.display = 'none'
-  })
-}
-
-const applyHeadlessMapMode = (emMap: EmMap) => {
-  const map = emMap.olMapInstance
-  if (!map) return
-
-  applyHeadlessUiTweaks(emMap)
-
-  const headlessSize = getHeadlessMapSizeFromUrl()
-  if (headlessSize) {
-    const mapElement = emMap as unknown as HTMLElement
-    mapElement.style.width = `${headlessSize.widthPx}px`
-    mapElement.style.height = `${headlessSize.heightPx}px`
-    map.updateSize()
+  return {
+    ...data,
+    matching: data.matching
+      ? {
+          ...data.matching,
+          deviceWearers: data.matching.deviceWearers.filter(deviceWearer =>
+            selectedDeviceIds.has(deviceWearer.deviceId),
+          ),
+        }
+      : undefined,
   }
-
-  map.renderSync()
 }
 
 const readJsonFromScript = <T>(id: string): T | undefined => {
@@ -238,150 +131,17 @@ const readJsonFromScript = <T>(id: string): T | undefined => {
   return undefined
 }
 
-const fitToDevicePositions = (emMap: EmMap, crimePosition: Position, devicePositions: Array<Position>) => {
-  emMap.fitToPoints([crimePosition, ...devicePositions], {
-    padding: 40,
-    maxZoom: 20,
-    animate: false,
-  })
-
-  const map = emMap.olMapInstance
-  const mapView = map?.getView()
-
-  if (!map || !mapView) return
-
-  const resolution = mapView.getResolution()
-  if (typeof resolution === 'number') {
-    mapView.setResolution(resolution * 1.3)
-  }
-
-  map.renderSync()
-}
-
-const setCheckboxCheckedState = (name: string, value: string, checked: boolean) => {
-  const checkbox = document.querySelector<HTMLInputElement>(`input[type="checkbox"][name="${name}"][value="${value}"]`)
-
-  if (!checkbox) return
-
-  checkbox.checked = checked
-  dispatchCheckboxChange(checkbox)
-}
-
-const setAllDeviceVisibility = (deviceIds: number[], selectedDeviceIds: Set<number>) => {
-  deviceIds.forEach(deviceId => {
-    setCheckboxCheckedState('device-wearer-toggle', `device-wearer-${deviceId}`, selectedDeviceIds.has(deviceId))
-  })
-}
-
-const setTrackVisibility = (deviceIds: number[], visibleDeviceIds: Set<number>) => {
-  deviceIds.forEach(deviceId => {
-    setCheckboxCheckedState('device-wearer-tracks', `device-wearer-tracks-${deviceId}`, visibleDeviceIds.has(deviceId))
-  })
-}
-
-const setAnalysisVisibility = (showConfidenceCircles: boolean, showLocationNumbering: boolean) => {
-  setCheckboxCheckedState('analysis-toggles', 'device-wearer-circles-', showConfidenceCircles)
-  setCheckboxCheckedState('analysis-toggles', 'device-wearer-labels-', showLocationNumbering)
-}
-
-// Build map render config based on preset selection and URL parameters
-const getRenderConfigForPreset = (
-  preset: PresetParam,
-  selectedDeviceIds: number[] | undefined,
-  focusedDeviceId?: number,
-): ExportMapRenderConfig => {
-  if (preset === 'overview-user-view') {
-    return {
-      selectedDeviceIds,
-      showTracks: true,
-      showConfidenceCircles: true,
-      showLocationNumbering: true,
-      fitToSelectedPositions: false,
-      fitToFocusedDevicePositions: false,
-    }
-  }
-
-  if (preset === 'overview-fitted') {
-    return {
-      selectedDeviceIds,
-      showTracks: false,
-      showConfidenceCircles: true,
-      showLocationNumbering: true,
-      fitToSelectedPositions: true,
-      fitToFocusedDevicePositions: false,
-    }
-  }
-
-  if (preset === 'wearer-overview') {
-    return {
-      selectedDeviceIds: focusedDeviceId ? [focusedDeviceId] : selectedDeviceIds,
-      focusedDeviceId,
-      showTracks: true,
-      showConfidenceCircles: true,
-      showLocationNumbering: true,
-      fitToSelectedPositions: false,
-      fitToFocusedDevicePositions: false,
-    }
-  }
-
-  return {
-    selectedDeviceIds: focusedDeviceId ? [focusedDeviceId] : selectedDeviceIds,
-    focusedDeviceId,
-    showTracks: false,
-    showConfidenceCircles: true,
-    showLocationNumbering: true,
-    fitToSelectedPositions: false,
-    fitToFocusedDevicePositions: true,
-  }
-}
-
-// Apply map render config to the map view by updating checkbox states and fitting view if needed
-const applyRenderConfig = (
-  emMap: EmMap,
-  data: MapData,
-  allDeviceIds: number[],
-  config: ExportMapRenderConfig,
-  crimeCentre: Coordinate,
-) => {
-  const selectedDeviceIds = new Set(config.selectedDeviceIds ?? allDeviceIds)
-  const visibleTrackDeviceIds = config.showTracks ? selectedDeviceIds : new Set<number>()
-
-  setAllDeviceVisibility(allDeviceIds, selectedDeviceIds)
-  setTrackVisibility(allDeviceIds, visibleTrackDeviceIds)
-  setAnalysisVisibility(config.showConfidenceCircles, config.showLocationNumbering)
-
-  if (config.fitToSelectedPositions) {
-    const positions =
-      data.matching?.deviceWearers
-        .filter(deviceWearer => selectedDeviceIds.has(deviceWearer.deviceId))
-        .flatMap(deviceWearer => deviceWearer.positions) ?? []
-
-    fitToDevicePositions(emMap, data.crimePosition, positions)
-    return
-  }
-
-  if (config.fitToFocusedDevicePositions && typeof config.focusedDeviceId === 'number') {
-    const focusedDeviceWearer = data.matching?.deviceWearers.find(
-      deviceWearer => deviceWearer.deviceId === config.focusedDeviceId,
-    )
-
-    fitToDevicePositions(emMap, data.crimePosition, focusedDeviceWearer?.positions ?? [])
-    return
-  }
-
-  setCrimeDefaultView(emMap, crimeCentre)
-}
-
+// Initialises the shared proximity alert map, then delegates user or headless export behaviour.
 const initialiseProximityAlertView = async () => {
-  const data = readJsonFromScript<MapData>('map-data')
+  const rawData = readJsonFromScript<MapData>('map-data')
 
-  if (!data) {
+  if (!rawData) {
     return
   }
 
   const emMap = queryElement(document, 'em-map') as EmMap
   const isHeadless = isHeadlessCapture()
-  const selectedDeviceIdsFromUrl = getSelectedDeviceIdsFromUrl()
+  const data = isHeadless ? filterMapDataForHeadlessExport(rawData) : rawData
 
   await new Promise<void>(resolve => {
     emMap.addEventListener('map:ready', () => resolve(), { once: true })
@@ -409,18 +169,14 @@ const initialiseProximityAlertView = async () => {
     }
   }
 
-  const win = window as unknown as { mapImages?: MapImagesApi }
-  win.mapImages = {
-    applyPreset: (preset: PresetParam, deviceId?: string) => {
-      const parsedDeviceId =
-        typeof deviceId === 'string' && deviceId.trim() !== '' ? Number(deviceId.trim()) : undefined
-
-      const config = getRenderConfigForPreset(preset, selectedDeviceIdsFromUrl, parsedDeviceId)
-      applyRenderConfig(emMap, data, allDeviceIds, config, centre)
-    },
-    applyCapturedMapState: (state: CapturedMapState) => {
-      applyCapturedMapState(emMap, state)
-    },
+  if (isHeadless) {
+    initialiseProximityAlertExportView({
+      emMap,
+      data,
+      mapDeviceIds: allDeviceIds,
+      setCrimeDefaultView: () => setCrimeDefaultView(emMap, centre),
+      applyCapturedMapState: state => applyCapturedMapState(emMap, state),
+    })
   }
 
   emMap.dispatchEvent(
@@ -430,19 +186,11 @@ const initialiseProximityAlertView = async () => {
     }),
   )
 
-  applyCheckboxLayerState()
-
-  const capturedMapState = getCapturedMapState()
-  if (capturedMapState) {
-    applyCapturedMapState(emMap, capturedMapState)
+  if (isHeadless === false) {
+    initialiseProximityAlertUserView({
+      applyCapturedMapState: state => applyCapturedMapState(emMap, state),
+    })
   }
-
-  if (isHeadless) {
-    applyHeadlessMapMode(emMap)
-    return
-  }
-
-  initialiseProximityAlertForm()
 }
 
 export default initialiseProximityAlertView

--- a/assets/js/views/proximity-alert/mapExport.ts
+++ b/assets/js/views/proximity-alert/mapExport.ts
@@ -1,0 +1,305 @@
+import { EmMap, Position } from '@ministryofjustice/hmpps-electronic-monitoring-components/map'
+import type { CapturedMapState, MapData } from './crimeVersion'
+
+type ExportMapFitMode = 'none' | 'selected-device-wearers' | 'focused-device-wearer'
+
+export type ExportMapRenderConfig = {
+  selectedDeviceIds: number[]
+  selectedTrackDeviceIds: number[]
+  focusedDeviceId?: number
+  showConfidenceCircles: boolean
+  showLocationNumbering: boolean
+  fitMode: ExportMapFitMode
+  capturedMapState?: CapturedMapState
+}
+
+type MapImagesApi = {
+  applyRenderConfig: (config: ExportMapRenderConfig) => Promise<void>
+}
+
+type InitialiseProximityAlertExportViewArgs = {
+  emMap: EmMap
+  data: MapData
+  mapDeviceIds: number[]
+  setCrimeDefaultView: () => void
+  applyCapturedMapState: (state: CapturedMapState) => void
+}
+
+type OlLayerLike = {
+  get?: (key: string) => unknown
+  setVisible?: (visible: boolean) => void
+  getLayers?: () => {
+    getArray: () => OlLayerLike[]
+  }
+}
+
+// Reads map dimensions from the headless export URL to match screenshot size to the user's original map view.
+const getHeadlessMapSizeFromUrl = (): { widthPx: number; heightPx: number } | null => {
+  const params = new URLSearchParams(window.location.search)
+  const mapWidthPx = params.get('mapWidthPx')
+  const mapHeightPx = params.get('mapHeightPx')
+
+  if (!mapWidthPx || !mapHeightPx) return null
+
+  const widthPx = Number(mapWidthPx)
+  const heightPx = Number(mapHeightPx)
+
+  if (!Number.isFinite(widthPx) || !Number.isFinite(heightPx) || widthPx <= 0 || heightPx <= 0) {
+    return null
+  }
+
+  return { widthPx, heightPx }
+}
+
+// Headless-only UI tweaks for export screenshots:
+const applyHeadlessUiTweaks = (emMap: EmMap) => {
+  const { shadowRoot } = emMap
+  if (!shadowRoot) return
+
+  const controls = shadowRoot.querySelectorAll<HTMLElement>('.ol-control, .ol-attribution')
+  controls.forEach(controlEl => {
+    const el = controlEl
+    el.style.display = 'none'
+  })
+}
+
+// Applies headless export settings (hide UI controls and resize map to match captured dimensions)
+// before rendering screenshots.
+const applyHeadlessMapMode = (emMap: EmMap) => {
+  const map = emMap.olMapInstance
+  if (!map) return
+
+  applyHeadlessUiTweaks(emMap)
+
+  const headlessMapSize = getHeadlessMapSizeFromUrl()
+  if (headlessMapSize) {
+    const mapElement = emMap as unknown as HTMLElement
+    mapElement.style.width = `${headlessMapSize.widthPx}px`
+    mapElement.style.height = `${headlessMapSize.heightPx}px`
+    map.updateSize()
+  }
+
+  map.renderSync()
+}
+
+// Fits the map view to the crime marker and supplied device wearer positions.
+const fitToDevicePositions = (emMap: EmMap, crimePosition: Position, devicePositions: Array<Position>) => {
+  emMap.fitToPoints([crimePosition, ...devicePositions], {
+    padding: 40,
+    maxZoom: 20,
+    animate: false,
+  })
+
+  const map = emMap.olMapInstance
+  const mapView = map?.getView()
+
+  if (!map || !mapView) return
+
+  const resolution = mapView.getResolution()
+  if (typeof resolution === 'number') {
+    mapView.setResolution(resolution * 1.3)
+  }
+
+  map.renderSync()
+}
+
+// Gets the identifier used to classify and match map layers.
+const getLayerKey = (layer: OlLayerLike): string => {
+  const id = layer.get?.('id')
+  const title = layer.get?.('title')
+
+  if (typeof id === 'string' && id.length > 0) return id
+  if (typeof title === 'string' && title.length > 0) return title
+
+  return ''
+}
+
+// Recursively traverses a layer and all child layers, applying a callback.
+const traverseLayers = (layer: OlLayerLike, callback: (layer: OlLayerLike) => void) => {
+  callback(layer)
+
+  layer
+    .getLayers?.()
+    .getArray()
+    .forEach(childLayer => traverseLayers(childLayer, callback))
+}
+
+// Applies a callback to every map layer, including nested child layers.
+const forEachMapLayer = (emMap: EmMap, callback: (layer: OlLayerLike) => void) => {
+  const layers = emMap.olMapInstance?.getLayers().getArray() as OlLayerLike[] | undefined
+
+  layers?.forEach(layer => traverseLayers(layer, callback))
+}
+
+// Checks whether a layer key belongs to the given device wearer.
+const layerKeyContainsDeviceId = (layerKey: string, deviceId: number): boolean => {
+  return layerKey.includes(String(deviceId))
+}
+
+// Checks whether a layer represents device wearer tracks.
+const isTracksLayer = (layerKey: string): boolean => {
+  const normalised = layerKey.toLowerCase()
+
+  return normalised.includes('track')
+}
+
+// Checks whether a layer represents confidence circles.
+const isConfidenceCirclesLayer = (layerKey: string): boolean => {
+  const normalised = layerKey.toLowerCase()
+
+  return normalised.includes('confidence') || normalised.includes('circle')
+}
+
+// Checks whether a layer represents location numbering labels.
+const isLocationNumberingLayer = (layerKey: string): boolean => {
+  const normalised = layerKey.toLowerCase()
+
+  return normalised.includes('label') || normalised.includes('number') || normalised.includes('text')
+}
+
+// Checks whether a layer belongs to the given device wearer.
+const isDeviceWearerLayer = (layerKey: string, deviceId: number): boolean => {
+  return layerKeyContainsDeviceId(layerKey, deviceId)
+}
+
+// Applies export visibility rules to device wearer layers.
+const setDeviceWearerLayersVisible = ({
+  emMap,
+  mapDeviceIds,
+  selectedDeviceIds,
+  selectedTrackDeviceIds,
+  showConfidenceCircles,
+  showLocationNumbering,
+}: {
+  emMap: EmMap
+  mapDeviceIds: number[]
+  selectedDeviceIds: Set<number>
+  selectedTrackDeviceIds: Set<number>
+  showConfidenceCircles: boolean
+  showLocationNumbering: boolean
+}) => {
+  forEachMapLayer(emMap, layer => {
+    const layerKey = getLayerKey(layer)
+    if (!layerKey) return
+
+    const matchingDeviceId = mapDeviceIds.find(deviceId => isDeviceWearerLayer(layerKey, deviceId))
+    if (typeof matchingDeviceId !== 'number') return
+
+    const isSelectedDeviceWearer = selectedDeviceIds.has(matchingDeviceId)
+
+    if (!isSelectedDeviceWearer) {
+      layer.setVisible?.(false)
+      return
+    }
+
+    if (isTracksLayer(layerKey)) {
+      layer.setVisible?.(selectedTrackDeviceIds.has(matchingDeviceId))
+      return
+    }
+
+    if (isConfidenceCirclesLayer(layerKey)) {
+      layer.setVisible?.(showConfidenceCircles)
+      return
+    }
+
+    if (isLocationNumberingLayer(layerKey)) {
+      layer.setVisible?.(showLocationNumbering)
+      return
+    }
+
+    layer.setVisible?.(true)
+  })
+}
+
+// Applies a screenshot-specific render config to layer visibility and map view.
+const applyRenderConfig = async ({
+  emMap,
+  data,
+  mapDeviceIds,
+  config,
+  setCrimeDefaultView,
+  applyCapturedMapState,
+}: {
+  emMap: EmMap
+  data: MapData
+  mapDeviceIds: number[]
+  config: ExportMapRenderConfig
+  setCrimeDefaultView: () => void
+  applyCapturedMapState: (state: CapturedMapState) => void
+}): Promise<void> => {
+  const selectedDeviceIds = new Set(config.selectedDeviceIds ?? mapDeviceIds)
+  const selectedTrackDeviceIds = new Set(config.selectedTrackDeviceIds ?? selectedDeviceIds)
+
+  const applyLayerVisibility = () => {
+    setDeviceWearerLayersVisible({
+      emMap,
+      mapDeviceIds,
+      selectedDeviceIds,
+      selectedTrackDeviceIds,
+      showConfidenceCircles: config.showConfidenceCircles,
+      showLocationNumbering: config.showLocationNumbering,
+    })
+  }
+
+  if (config.capturedMapState) {
+    applyCapturedMapState(config.capturedMapState)
+
+    await new Promise<void>(resolve => {
+      window.requestAnimationFrame(() => resolve())
+    })
+
+    applyLayerVisibility()
+    emMap.olMapInstance?.renderSync()
+    return
+  }
+
+  applyLayerVisibility()
+
+  if (config.fitMode === 'selected-device-wearers') {
+    const positions =
+      data.matching?.deviceWearers
+        .filter(deviceWearer => selectedDeviceIds.has(deviceWearer.deviceId))
+        .flatMap(deviceWearer => deviceWearer.positions) ?? []
+
+    fitToDevicePositions(emMap, data.crimePosition, positions)
+    return
+  }
+
+  if (config.fitMode === 'focused-device-wearer' && typeof config.focusedDeviceId === 'number') {
+    const focusedDeviceWearer = data.matching?.deviceWearers.find(
+      deviceWearer => deviceWearer.deviceId === config.focusedDeviceId,
+    )
+
+    fitToDevicePositions(emMap, data.crimePosition, focusedDeviceWearer?.positions ?? [])
+    return
+  }
+
+  setCrimeDefaultView()
+}
+
+// Initialises the headless export API used in the Service by Playwright to configure screenshots.
+const initialiseProximityAlertExportView = ({
+  emMap,
+  data,
+  mapDeviceIds,
+  setCrimeDefaultView,
+  applyCapturedMapState,
+}: InitialiseProximityAlertExportViewArgs) => {
+  applyHeadlessMapMode(emMap)
+
+  const win = window as unknown as { mapImages?: MapImagesApi }
+  win.mapImages = {
+    applyRenderConfig: async (config: ExportMapRenderConfig) => {
+      await applyRenderConfig({
+        emMap,
+        data,
+        mapDeviceIds,
+        config,
+        setCrimeDefaultView,
+        applyCapturedMapState,
+      })
+    },
+  }
+}
+
+export default initialiseProximityAlertExportView

--- a/assets/js/views/proximity-alert/mapExport.ts
+++ b/assets/js/views/proximity-alert/mapExport.ts
@@ -85,7 +85,7 @@ const applyHeadlessMapMode = (emMap: EmMap) => {
 // Fits the map view to the crime marker and supplied device wearer positions.
 const fitToDevicePositions = (emMap: EmMap, crimePosition: Position, devicePositions: Array<Position>) => {
   emMap.fitToPoints([crimePosition, ...devicePositions], {
-    padding: 40,
+    padding: 100,
     maxZoom: 20,
     animate: false,
   })
@@ -94,11 +94,6 @@ const fitToDevicePositions = (emMap: EmMap, crimePosition: Position, devicePosit
   const mapView = map?.getView()
 
   if (!map || !mapView) return
-
-  const resolution = mapView.getResolution()
-  if (typeof resolution === 'number') {
-    mapView.setResolution(resolution * 1.3)
-  }
 
   map.renderSync()
 }

--- a/assets/js/views/proximity-alert/mapUserView.ts
+++ b/assets/js/views/proximity-alert/mapUserView.ts
@@ -1,0 +1,85 @@
+import initialiseProximityAlertForm from '../../forms/proximity-alert'
+import { queryElementAll } from '../../utils/utils'
+import type { CapturedMapState } from './crimeVersion'
+
+type InitialiseProximityAlertUserViewArgs = {
+  applyCapturedMapState: (state: CapturedMapState) => void
+}
+
+const dispatchCheckboxChange = (checkbox: HTMLInputElement) => {
+  checkbox.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+const applyCheckboxLayerState = () => {
+  const selectors = [
+    'input[type="checkbox"][name="device-wearer-toggle"]',
+    'input[type="checkbox"][name="device-wearer-tracks"]',
+    'input[type="checkbox"][name="analysis-toggles"]',
+  ]
+
+  for (const selector of selectors) {
+    const checkboxes = queryElementAll(document, selector, HTMLInputElement)
+
+    checkboxes.forEach(checkbox => {
+      dispatchCheckboxChange(checkbox)
+    })
+  }
+}
+
+// Type guard to validate the structure of the captured map state
+const isValidCapturedMapState = (parsedMapState: unknown): parsedMapState is CapturedMapState => {
+  if (!parsedMapState || typeof parsedMapState !== 'object') return false
+
+  const parsedState = parsedMapState as {
+    mapWidthPx?: unknown
+    mapHeightPx?: unknown
+    devicePixelRatio?: unknown
+    view?: {
+      center?: unknown
+      resolution?: unknown
+      rotation?: unknown
+    }
+  }
+
+  return (
+    typeof parsedState.mapWidthPx === 'number' &&
+    typeof parsedState.mapHeightPx === 'number' &&
+    typeof parsedState.devicePixelRatio === 'number' &&
+    !!parsedState.view &&
+    Array.isArray(parsedState.view.center) &&
+    parsedState.view.center.length === 2 &&
+    typeof parsedState.view.center[0] === 'number' &&
+    typeof parsedState.view.center[1] === 'number' &&
+    typeof parsedState.view.resolution === 'number' &&
+    typeof parsedState.view.rotation === 'number'
+  )
+}
+
+// Attempt to read captured map state from hidden input field
+const getCapturedMapState = (): CapturedMapState | undefined => {
+  const mapStateInput = document.querySelector<HTMLInputElement>('#capturedMapState')
+  if (!mapStateInput) return undefined
+
+  const mapStateValue = mapStateInput.value.trim()
+  if (!mapStateValue) return undefined
+
+  try {
+    const parsedMapState: unknown = JSON.parse(mapStateValue)
+    return isValidCapturedMapState(parsedMapState) ? parsedMapState : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const initialiseProximityAlertUserView = ({ applyCapturedMapState }: InitialiseProximityAlertUserViewArgs) => {
+  applyCheckboxLayerState()
+
+  const capturedMapState = getCapturedMapState()
+  if (capturedMapState) {
+    applyCapturedMapState(capturedMapState)
+  }
+
+  initialiseProximityAlertForm()
+}
+
+export default initialiseProximityAlertUserView

--- a/server/controllers/proximityAlert/crimeVersion.test.ts
+++ b/server/controllers/proximityAlert/crimeVersion.test.ts
@@ -446,16 +446,24 @@ describe('CrimeVersionController', () => {
   })
 
   describe('exportProximityAlert', () => {
-    it('should redirect back with a session error when the export request is invalid', async () => {
+    it('should redirect back with a session error when no device ids are selected', async () => {
       // Given
       const crimeVersionId = '78d41bd9-5450-4bbb-89d4-42ba75659f50'
       const req = createMockRequest({
         params: { crimeVersionId },
         body: {
-          'device-wearer-toggle': ['device-wearer-1'],
           'device-wearer-tracks': ['device-wearer-tracks-1'],
-          'analysis-toggles': ['device-wearer-labels-'],
-          capturedMapState: '{invalid-json}',
+          'analysis-toggles': ['device-wearer-circles-'],
+          capturedMapState: JSON.stringify({
+            mapWidthPx: 1200,
+            mapHeightPx: 800,
+            devicePixelRatio: 2,
+            view: {
+              center: [12345, 67890],
+              resolution: 4.5,
+              rotation: 0,
+            },
+          }),
         },
       })
       const res = createMockResponse()
@@ -482,7 +490,7 @@ describe('CrimeVersionController', () => {
           latitude: 10.0,
           longitude: 10.0,
           matching: {
-            deviceWearers: [{ name: 'name', deviceId: 1, nomisId: 'nomisId', positions: [] }],
+            deviceWearers: [{ name: 'name1', deviceId: 1, nomisId: 'nomisId1', positions: [] }],
           },
         },
       })
@@ -492,12 +500,21 @@ describe('CrimeVersionController', () => {
 
       // Then
       expect(req.session.exportProximityAlertState).toEqual({
-        error: 'Invalid export request.',
-        selectedDeviceIds: ['1'],
-        selectedTrackDeviceIds: ['1'],
-        showConfidenceCircles: false,
-        showLocationNumbering: true,
-        capturedMapState: '{invalid-json}',
+        error: 'Select at least one device wearer to export the Proximity Alert report.',
+        selectedDeviceIds: [],
+        selectedTrackDeviceIds: [],
+        showConfidenceCircles: true,
+        showLocationNumbering: false,
+        capturedMapState: JSON.stringify({
+          mapWidthPx: 1200,
+          mapHeightPx: 800,
+          devicePixelRatio: 2,
+          view: {
+            center: [12345, 67890],
+            resolution: 4.5,
+            rotation: 0,
+          },
+        }),
       })
       expect(res.redirect).toHaveBeenCalledWith(`/proximity-alert/${crimeVersionId}`)
       expect(next).not.toHaveBeenCalled()
@@ -665,7 +682,7 @@ describe('CrimeVersionController', () => {
       expect(req.session.exportProximityAlertState).toEqual({
         error: 'Select at least one device wearer to export the Proximity Alert report.',
         selectedDeviceIds: [],
-        selectedTrackDeviceIds: ['1'],
+        selectedTrackDeviceIds: [],
         showConfidenceCircles: true,
         showLocationNumbering: false,
         capturedMapState: JSON.stringify({

--- a/server/controllers/proximityAlert/crimeVersion.ts
+++ b/server/controllers/proximityAlert/crimeVersion.ts
@@ -75,7 +75,8 @@ export default class CrimeVersionController {
           )
           res.redirect(redirectUrl)
         } else {
-          const { deviceIds, capturedMapState } = parsedRequest.exportData
+          const { deviceIds, selectedTrackDeviceIds, capturedMapState, showConfidenceCircles, showLocationNumbering } =
+            parsedRequest.exportData
 
           if (deviceIds.length === 0) {
             req.session.exportProximityAlertState = withExportProximityAlertError(
@@ -92,7 +93,10 @@ export default class CrimeVersionController {
               baseUrlForCookies: config.ingressUrl,
               cookieHeader: req.headers.cookie,
               selectedDeviceIds: deviceIds,
+              selectedTrackDeviceIds,
               capturedMapState,
+              showConfidenceCircles,
+              showLocationNumbering,
             })
 
             const zipFileName = `proximity-alert-${crimeVersionId}-map-images.zip`

--- a/server/form-pages/proximityAlert/exportProximityAlert.test.ts
+++ b/server/form-pages/proximityAlert/exportProximityAlert.test.ts
@@ -34,7 +34,10 @@ describe('exportProximityAlert form page', () => {
         success: true,
         exportData: {
           deviceIds: ['1', '2'],
+          selectedTrackDeviceIds: ['1'],
           capturedMapState,
+          showConfidenceCircles: true,
+          showLocationNumbering: true,
         },
         formState: {
           selectedDeviceIds: ['1', '2'],
@@ -74,7 +77,10 @@ describe('exportProximityAlert form page', () => {
         success: true,
         exportData: {
           deviceIds: ['1'],
+          selectedTrackDeviceIds: ['1'],
           capturedMapState,
+          showConfidenceCircles: false,
+          showLocationNumbering: true,
         },
         formState: {
           selectedDeviceIds: ['1'],
@@ -100,7 +106,10 @@ describe('exportProximityAlert form page', () => {
         success: true,
         exportData: {
           deviceIds: ['1'],
+          selectedTrackDeviceIds: [],
           capturedMapState: undefined,
+          showConfidenceCircles: false,
+          showLocationNumbering: false,
         },
         formState: {
           selectedDeviceIds: ['1'],
@@ -128,7 +137,10 @@ describe('exportProximityAlert form page', () => {
         success: true,
         exportData: {
           deviceIds: ['1', '2'],
+          selectedTrackDeviceIds: ['1'],
           capturedMapState: undefined,
+          showConfidenceCircles: true,
+          showLocationNumbering: false,
         },
         formState: {
           selectedDeviceIds: ['1', '2'],

--- a/server/form-pages/proximityAlert/exportProximityAlert.ts
+++ b/server/form-pages/proximityAlert/exportProximityAlert.ts
@@ -23,7 +23,10 @@ export type ExportProximityAlertForm = {
 
 type ParsedExportProximityAlertData = {
   deviceIds: string[]
+  selectedTrackDeviceIds: string[]
   capturedMapState?: string
+  showConfidenceCircles: boolean
+  showLocationNumbering: boolean
 }
 
 export type ParsedExportProximityAlertRequest =
@@ -111,11 +114,24 @@ export const parseExportProximityAlertRequest = (body: Record<string, unknown>):
     }
   }
 
+  // Ensures track visibility is only applied to device wearers that are also selected for export.
+  const selectedTrackDeviceIds = formState.selectedTrackDeviceIds.filter(deviceId =>
+    formState.selectedDeviceIds.includes(deviceId),
+  )
+
   // If validation passes, return the parsed export data along with the form state for potential reuse in the UI
   return {
     success: true,
-    exportData: formData.data,
-    formState,
+    exportData: {
+      ...formData.data,
+      selectedTrackDeviceIds,
+      showConfidenceCircles: formState.showConfidenceCircles,
+      showLocationNumbering: formState.showLocationNumbering,
+    },
+    formState: {
+      ...formState,
+      selectedTrackDeviceIds,
+    },
   }
 }
 

--- a/server/services/proximityAlert/proximityAlertMapImageService.test.ts
+++ b/server/services/proximityAlert/proximityAlertMapImageService.test.ts
@@ -1,6 +1,17 @@
 import MapImageRendererService from './proximityAlertMapImageService'
 
 describe('MapImageRendererService', () => {
+  const capturedMapState = JSON.stringify({
+    mapWidthPx: 1200,
+    mapHeightPx: 800,
+    devicePixelRatio: 2,
+    view: {
+      center: [12345, 67890],
+      resolution: 4.5,
+      rotation: 0,
+    },
+  })
+
   const createMockPage = () => {
     // Fake screenshot buffers to be returned by the mocked map element's screenshot method
     const screenshotBuffers = [
@@ -55,24 +66,16 @@ describe('MapImageRendererService', () => {
     const browser = createMockBrowser(context)
     const service = new MapImageRendererService()
 
-    const capturedMapState = JSON.stringify({
-      mapWidthPx: 1200,
-      mapHeightPx: 800,
-      devicePixelRatio: 2,
-      view: {
-        center: [12345, 67890],
-        resolution: 4.5,
-        rotation: 0,
-      },
-    })
-
     const result = await service.render({
       browser: browser as never,
       pageUrl: 'https://example.test/proximity-alert/123',
       baseUrlForCookies: 'https://example.test',
       cookieHeader: 'connect.sid=fake-session; foo=bar',
       selectedDeviceIds: ['1', '2'],
+      selectedTrackDeviceIds: ['1'],
       capturedMapState,
+      showConfidenceCircles: false,
+      showLocationNumbering: true,
     })
 
     expect(browser.newContext).toHaveBeenCalledWith({
@@ -91,53 +94,91 @@ describe('MapImageRendererService', () => {
     expect(page.setDefaultNavigationTimeout).toHaveBeenCalledWith(30_000)
 
     expect(page.goto).toHaveBeenCalledWith(
-      'https://example.test/proximity-alert/123?headless=true&deviceIds=1%2C2&mapWidthPx=1200&mapHeightPx=800',
+      'https://example.test/proximity-alert/123?headless=true&mapWidthPx=1200&mapHeightPx=800&selectedDeviceIds=1%2C2',
       { waitUntil: 'domcontentloaded' },
     )
 
     expect(page.evaluate).toHaveBeenCalledWith(
       expect.any(Function),
       expect.objectContaining({
-        presetValue: 'overview-user-view',
-      }),
-    )
-
-    expect(page.evaluate).toHaveBeenCalledWith(
-      expect.any(Function),
-      expect.objectContaining({
-        presetValue: 'overview-fitted-to-device-wearers',
-      }),
-    )
-
-    expect(page.evaluate).toHaveBeenCalledWith(
-      expect.any(Function),
-      expect.objectContaining({
-        presetValue: 'device-wearer-with-tracks',
-        deviceIdValue: '1',
-      }),
-    )
-
-    expect(page.evaluate).toHaveBeenCalledWith(
-      expect.any(Function),
-      expect.objectContaining({
-        presetValue: 'device-wearer-fitted-without-tracks',
-        deviceIdValue: '1',
-      }),
-    )
-
-    expect(page.evaluate).toHaveBeenCalledWith(
-      expect.any(Function),
-      expect.objectContaining({
-        capturedMapStateValue: {
-          mapWidthPx: 1200,
-          mapHeightPx: 800,
-          devicePixelRatio: 2,
-          view: {
-            center: [12345, 67890],
-            resolution: 4.5,
-            rotation: 0,
+        renderConfig: expect.objectContaining({
+          selectedDeviceIds: [1, 2],
+          selectedTrackDeviceIds: [1],
+          showConfidenceCircles: false,
+          showLocationNumbering: true,
+          fitMode: 'none',
+          capturedMapState: {
+            mapWidthPx: 1200,
+            mapHeightPx: 800,
+            devicePixelRatio: 2,
+            view: {
+              center: [12345, 67890],
+              resolution: 4.5,
+              rotation: 0,
+            },
           },
-        },
+        }),
+      }),
+    )
+
+    expect(page.evaluate).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        renderConfig: expect.objectContaining({
+          selectedDeviceIds: [1],
+          selectedTrackDeviceIds: [1],
+          focusedDeviceId: 1,
+          fitMode: 'none',
+        }),
+      }),
+    )
+
+    expect(page.evaluate).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        renderConfig: expect.objectContaining({
+          selectedDeviceIds: [2],
+          selectedTrackDeviceIds: [2],
+          focusedDeviceId: 2,
+          fitMode: 'none',
+        }),
+      }),
+    )
+
+    expect(page.evaluate).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        renderConfig: expect.objectContaining({
+          selectedDeviceIds: [1, 2],
+          selectedTrackDeviceIds: [],
+          showConfidenceCircles: true,
+          showLocationNumbering: true,
+          fitMode: 'selected-device-wearers',
+        }),
+      }),
+    )
+
+    expect(page.evaluate).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        renderConfig: expect.objectContaining({
+          selectedDeviceIds: [1],
+          selectedTrackDeviceIds: [],
+          focusedDeviceId: 1,
+          fitMode: 'focused-device-wearer',
+        }),
+      }),
+    )
+
+    expect(page.evaluate).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        renderConfig: expect.objectContaining({
+          selectedDeviceIds: [2],
+          selectedTrackDeviceIds: [],
+          focusedDeviceId: 2,
+          fitMode: 'focused-device-wearer',
+        }),
       }),
     )
 
@@ -171,16 +212,10 @@ describe('MapImageRendererService', () => {
         pageUrl: 'https://example.test/proximity-alert/123',
         baseUrlForCookies: 'https://example.test',
         selectedDeviceIds: [],
-        capturedMapState: JSON.stringify({
-          mapWidthPx: 1200,
-          mapHeightPx: 800,
-          devicePixelRatio: 2,
-          view: {
-            center: [12345, 67890],
-            resolution: 4.5,
-            rotation: 0,
-          },
-        }),
+        selectedTrackDeviceIds: [],
+        capturedMapState,
+        showConfidenceCircles: true,
+        showLocationNumbering: true,
       }),
     ).rejects.toThrow('cookieHeader is required to render proximity alert report images')
 
@@ -200,16 +235,10 @@ describe('MapImageRendererService', () => {
         baseUrlForCookies: 'https://example.test',
         cookieHeader: '   ;   ',
         selectedDeviceIds: [],
-        capturedMapState: JSON.stringify({
-          mapWidthPx: 1200,
-          mapHeightPx: 800,
-          devicePixelRatio: 2,
-          view: {
-            center: [12345, 67890],
-            resolution: 4.5,
-            rotation: 0,
-          },
-        }),
+        selectedTrackDeviceIds: [],
+        capturedMapState,
+        showConfidenceCircles: true,
+        showLocationNumbering: true,
       }),
     ).rejects.toThrow('cookieHeader must contain at least one valid cookie to render proximity alert report images')
 
@@ -236,6 +265,9 @@ describe('MapImageRendererService', () => {
         baseUrlForCookies: 'https://example.test',
         cookieHeader: 'connect.sid=fake-session; foo=bar',
         selectedDeviceIds: [],
+        selectedTrackDeviceIds: [],
+        showConfidenceCircles: true,
+        showLocationNumbering: true,
       }),
     ).rejects.toThrow('capturedMapState is required and must be valid to render proximity alert report images')
 
@@ -255,7 +287,10 @@ describe('MapImageRendererService', () => {
         baseUrlForCookies: 'https://example.test',
         cookieHeader: 'connect.sid=fake-session; foo=bar',
         selectedDeviceIds: ['1'],
+        selectedTrackDeviceIds: ['1'],
         capturedMapState: '{invalid-json}',
+        showConfidenceCircles: true,
+        showLocationNumbering: true,
       }),
     ).rejects.toThrow('capturedMapState is required and must be valid to render proximity alert report images')
 
@@ -277,16 +312,10 @@ describe('MapImageRendererService', () => {
         baseUrlForCookies: 'https://example.test',
         cookieHeader: 'connect.sid=fake-session; foo=bar',
         selectedDeviceIds: [],
-        capturedMapState: JSON.stringify({
-          mapWidthPx: 1200,
-          mapHeightPx: 800,
-          devicePixelRatio: 2,
-          view: {
-            center: [12345, 67890],
-            resolution: 4.5,
-            rotation: 0,
-          },
-        }),
+        selectedTrackDeviceIds: [],
+        capturedMapState,
+        showConfidenceCircles: true,
+        showLocationNumbering: true,
       }),
     ).rejects.toThrow('Map element <em-map> not found for screenshot')
 

--- a/server/services/proximityAlert/proximityAlertMapImageService.ts
+++ b/server/services/proximityAlert/proximityAlertMapImageService.ts
@@ -4,23 +4,17 @@ import {
   type CapturedMapStateValue,
 } from '../../schemas/proximityAlert/exportProximityAlert'
 
-type ValueOf<T> = T[keyof T]
+type ExportMapFitMode = 'none' | 'selected-device-wearers' | 'focused-device-wearer'
 
-const MAP_IMAGE_PRESETS = {
-  // Replays the user's submitted browser view using captured map state.
-  overviewUserView: 'overview-user-view',
-
-  // Shows all selected device wearers without tracks, fitted to the cluster.
-  overviewFittedToDeviceWearers: 'overview-fitted-to-device-wearers',
-
-  // Shows a single device wearer with tracks visible.
-  deviceWearerWithTracks: 'device-wearer-with-tracks',
-
-  // Shows a single device wearer without tracks, fitted tightly to its positions.
-  deviceWearerFittedWithoutTracks: 'device-wearer-fitted-without-tracks',
-} as const
-
-type PresetParam = ValueOf<typeof MAP_IMAGE_PRESETS>
+type ExportMapRenderConfig = {
+  selectedDeviceIds?: number[]
+  selectedTrackDeviceIds?: number[]
+  focusedDeviceId?: number
+  showConfidenceCircles: boolean
+  showLocationNumbering: boolean
+  fitMode: ExportMapFitMode
+  capturedMapState?: CapturedMapStateValue
+}
 
 export type ProximityAlertReportImages = {
   overviewUserViewJpg?: Buffer
@@ -35,7 +29,10 @@ export type RenderProximityAlertImagesArgs = {
   baseUrlForCookies: string
   cookieHeader?: string
   selectedDeviceIds: string[]
+  selectedTrackDeviceIds: string[]
   capturedMapState?: string
+  showConfidenceCircles: boolean
+  showLocationNumbering: boolean
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000
@@ -78,25 +75,81 @@ const tryParseCapturedMapState = (capturedMapState?: string): CapturedMapStateVa
   }
 }
 
+// Converts selected device IDs from strings to valid numeric IDs for map rendering.
+const parseSelectedDeviceIds = (selectedDeviceIds: string[]): number[] => {
+  return selectedDeviceIds.map(deviceId => Number(deviceId)).filter(deviceId => Number.isFinite(deviceId))
+}
+
 // Build a URL for headless export.
-const pageUrlForHeadless = (
-  baseUrl: string,
-  selectedDeviceIds: string[],
-  capturedMapState: CapturedMapStateValue,
-): string => {
+const pageUrlForHeadless = ({
+  baseUrl,
+  capturedMapState,
+  selectedDeviceIds,
+}: {
+  baseUrl: string
+  capturedMapState: CapturedMapStateValue
+  selectedDeviceIds: number[]
+}): string => {
   const url = new URL(baseUrl)
 
   url.searchParams.set('headless', 'true')
-
-  if (selectedDeviceIds.length > 0) {
-    url.searchParams.set('deviceIds', selectedDeviceIds.join(','))
-  }
-
   url.searchParams.set('mapWidthPx', String(capturedMapState.mapWidthPx))
   url.searchParams.set('mapHeightPx', String(capturedMapState.mapHeightPx))
+  url.searchParams.set('selectedDeviceIds', selectedDeviceIds.join(','))
 
   return url.toString()
 }
+
+// Replays the user's submitted browser view using captured map state.
+const overviewUserViewConfig = ({
+  selectedDeviceIds,
+  selectedTrackDeviceIds,
+  capturedMapState,
+  showConfidenceCircles,
+  showLocationNumbering,
+}: {
+  selectedDeviceIds: number[]
+  selectedTrackDeviceIds: number[]
+  capturedMapState: CapturedMapStateValue
+  showConfidenceCircles: boolean
+  showLocationNumbering: boolean
+}): ExportMapRenderConfig => ({
+  selectedDeviceIds,
+  selectedTrackDeviceIds,
+  showConfidenceCircles,
+  showLocationNumbering,
+  fitMode: 'none',
+  capturedMapState,
+})
+
+// Shows all selected device wearers without tracks, fitted to the cluster.
+const overviewFittedToDeviceWearersConfig = (selectedDeviceIds: number[]): ExportMapRenderConfig => ({
+  selectedDeviceIds,
+  selectedTrackDeviceIds: [],
+  showConfidenceCircles: true,
+  showLocationNumbering: true,
+  fitMode: 'selected-device-wearers',
+})
+
+// Shows a single device wearer with tracks visible.
+const deviceWearerWithTracksConfig = (deviceId: number): ExportMapRenderConfig => ({
+  selectedDeviceIds: [deviceId],
+  selectedTrackDeviceIds: [deviceId],
+  focusedDeviceId: deviceId,
+  showConfidenceCircles: true,
+  showLocationNumbering: true,
+  fitMode: 'none',
+})
+
+// Shows a single device wearer without tracks, fitted to the device.
+const deviceWearerFittedWithoutTracksConfig = (deviceId: number): ExportMapRenderConfig => ({
+  selectedDeviceIds: [deviceId],
+  selectedTrackDeviceIds: [],
+  focusedDeviceId: deviceId,
+  showConfidenceCircles: true,
+  showLocationNumbering: true,
+  fitMode: 'focused-device-wearer',
+})
 
 // Wait until the client-side map code has added all custom layers.
 const waitForAppLayersReady = async (page: Page): Promise<void> => {
@@ -142,43 +195,22 @@ const waitForOlRenderComplete = async (page: Page): Promise<void> => {
   })
 }
 
-// Apply a map preset in the headless page to set layer visibility and styles for screenshots.
-const applyPreset = async (page: Page, preset: PresetParam, deviceId?: string): Promise<void> => {
+// Apply a map render config in the headless page to set layer visibility and viewport for screenshots.
+const applyRenderConfig = async (page: Page, config: ExportMapRenderConfig): Promise<void> => {
   await page.evaluate(
-    ({ presetValue, deviceIdValue }) => {
+    async ({ renderConfig }) => {
       const win = globalThis as unknown as {
-        mapImages?: { applyPreset?: (preset: string, deviceId?: string) => void }
+        mapImages?: { applyRenderConfig?: (config: unknown) => Promise<void> }
       }
 
-      if (!win.mapImages?.applyPreset) {
-        throw new Error('window.mapImages.applyPreset not found')
+      if (!win.mapImages?.applyRenderConfig) {
+        throw new Error('window.mapImages.applyRenderConfig not found')
       }
 
-      win.mapImages.applyPreset(presetValue, deviceIdValue)
+      await win.mapImages.applyRenderConfig(renderConfig)
     },
     {
-      presetValue: preset,
-      deviceIdValue: deviceId,
-    },
-  )
-}
-
-// Apply the captured map state in the headless page to set the map view for the user-view overview screenshot.
-const applyCapturedMapState = async (page: Page, capturedMapState: CapturedMapStateValue): Promise<void> => {
-  await page.evaluate(
-    ({ capturedMapStateValue }) => {
-      const win = globalThis as unknown as {
-        mapImages?: { applyCapturedMapState?: (state: unknown) => void }
-      }
-
-      if (!win.mapImages?.applyCapturedMapState) {
-        throw new Error('window.mapImages.applyCapturedMapState not found')
-      }
-
-      win.mapImages.applyCapturedMapState(capturedMapStateValue)
-    },
-    {
-      capturedMapStateValue: capturedMapState,
+      renderConfig: config,
     },
   )
 }
@@ -199,7 +231,17 @@ const screenshotMapElement = async (page: Page): Promise<Buffer> => {
 export default class MapImageRendererService {
   // Render map images for the proximity alert report based on the provided arguments, returning them as buffers.
   async render(args: RenderProximityAlertImagesArgs): Promise<ProximityAlertReportImages> {
-    const { browser, pageUrl, baseUrlForCookies, cookieHeader, selectedDeviceIds, capturedMapState } = args
+    const {
+      browser,
+      pageUrl,
+      baseUrlForCookies,
+      cookieHeader,
+      selectedDeviceIds,
+      selectedTrackDeviceIds,
+      capturedMapState,
+      showConfidenceCircles,
+      showLocationNumbering,
+    } = args
 
     if (!cookieHeader) {
       throw new Error('cookieHeader is required to render proximity alert report images')
@@ -209,6 +251,9 @@ export default class MapImageRendererService {
     if (!parsedCapturedMapState) {
       throw new Error('capturedMapState is required and must be valid to render proximity alert report images')
     }
+
+    const selectedDeviceIdsAsNumbers = parseSelectedDeviceIds(selectedDeviceIds)
+    const selectedTrackDeviceIdsAsNumbers = parseSelectedDeviceIds(selectedTrackDeviceIds)
 
     const context = await browser.newContext({
       viewport: DEFAULT_VIEWPORT,
@@ -226,14 +271,26 @@ export default class MapImageRendererService {
       page.setDefaultTimeout(DEFAULT_TIMEOUT_MS)
       page.setDefaultNavigationTimeout(DEFAULT_TIMEOUT_MS)
 
-      const targetUrl = pageUrlForHeadless(pageUrl, selectedDeviceIds, parsedCapturedMapState)
+      const targetUrl = pageUrlForHeadless({
+        baseUrl: pageUrl,
+        capturedMapState: parsedCapturedMapState,
+        selectedDeviceIds: selectedDeviceIdsAsNumbers,
+      })
 
       await page.goto(targetUrl, { waitUntil: 'domcontentloaded' })
       await waitForAppLayersReady(page)
       await waitForOlRenderComplete(page)
-      // Overview image that reproduces the user's current browser map view.
-      await applyPreset(page, MAP_IMAGE_PRESETS.overviewUserView)
-      await applyCapturedMapState(page, parsedCapturedMapState)
+
+      await applyRenderConfig(
+        page,
+        overviewUserViewConfig({
+          selectedDeviceIds: selectedDeviceIdsAsNumbers,
+          selectedTrackDeviceIds: selectedTrackDeviceIdsAsNumbers,
+          capturedMapState: parsedCapturedMapState,
+          showConfidenceCircles,
+          showLocationNumbering,
+        }),
+      )
       await waitForOlRenderComplete(page)
       const overviewUserViewJpg = await screenshotMapElement(page)
 
@@ -242,24 +299,24 @@ export default class MapImageRendererService {
       // Capture similar map states together to avoid repeatedly switching between overview and detail views.
       // Large view changes can trigger extra tile loading/rendering, so grouping screenshots reduces export time.
       /* eslint-disable no-await-in-loop -- Intentional: keep map state changes and screenshots sequential */
-      for (const deviceId of selectedDeviceIds) {
-        await applyPreset(page, MAP_IMAGE_PRESETS.deviceWearerWithTracks, deviceId)
+      for (const deviceId of selectedDeviceIdsAsNumbers) {
+        await applyRenderConfig(page, deviceWearerWithTracksConfig(deviceId))
         await waitForOlRenderComplete(page)
-        deviceWearerWithTracksJpgByDeviceId[deviceId] = await screenshotMapElement(page)
+        deviceWearerWithTracksJpgByDeviceId[String(deviceId)] = await screenshotMapElement(page)
       }
       /* eslint-enable no-await-in-loop */
 
-      await applyPreset(page, MAP_IMAGE_PRESETS.overviewFittedToDeviceWearers)
+      await applyRenderConfig(page, overviewFittedToDeviceWearersConfig(selectedDeviceIdsAsNumbers))
       await waitForOlRenderComplete(page)
       const overviewFittedToDeviceWearersJpg = await screenshotMapElement(page)
 
       const deviceWearerFittedWithoutTracksJpgByDeviceId: Record<string, Buffer> = {}
 
       /* eslint-disable no-await-in-loop -- Intentional: keep map state changes and screenshots sequential */
-      for (const deviceId of selectedDeviceIds) {
-        await applyPreset(page, MAP_IMAGE_PRESETS.deviceWearerFittedWithoutTracks, deviceId)
+      for (const deviceId of selectedDeviceIdsAsNumbers) {
+        await applyRenderConfig(page, deviceWearerFittedWithoutTracksConfig(deviceId))
         await waitForOlRenderComplete(page)
-        deviceWearerFittedWithoutTracksJpgByDeviceId[deviceId] = await screenshotMapElement(page)
+        deviceWearerFittedWithoutTracksJpgByDeviceId[String(deviceId)] = await screenshotMapElement(page)
       }
       /* eslint-enable no-await-in-loop */
 


### PR DESCRIPTION
- Split proximity alert map client code into shared setup, user view behaviour, and headless export behaviour.
- Replaced export presets with applyRenderConfig calls for each screenshot.
- Added per-device track visibility so overview-user-view.jpg reflects the user’s selected track toggles.
- Added headless export filtering so only selected device wearers are created as export map layers.
- Preserved original device wearer palette ordering when export data is filtered.
- Updated export tests.

Haven't implemented purely URL driven map as not required for the optimal way to generate export images, but should be easy to add if deemed valuable at a later date.