### PR TITLE
Create a framework for removing magic url strings

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -26,6 +26,7 @@ import setUpWebSession from './middleware/setUpWebSession'
 
 import routes from './routes'
 import type { Services } from './services'
+import populateConstants from './middleware/populateConstants'
 
 // Loads Probation Design System components into the request
 async function loadPdsComponents(req: express.Request, res: express.Response): Promise<void> {
@@ -75,6 +76,7 @@ export default function createApp(services: Services): express.Application {
   app.use(multer().single('file'))
   app.use(setUpCsrf())
   app.use(setUpCurrentUser())
+  app.use(populateConstants)
 
   app.get(
     '*splat',

--- a/server/constants/urls.ts
+++ b/server/constants/urls.ts
@@ -1,7 +1,9 @@
 const URLS = {
-  HUB_MANAGERS__LIST: '/hub-managers' as const,
-  HUB_MANAGERS__CREATE: '/hub-managers/create' as const,
-  HUB_MANAGERS__DELETE: '/hub-managers/:id/delete' as const,
+  HUB_MANAGERS: {
+    LIST: '/hub-managers' as const,
+    CREATE: '/hub-managers/create' as const,
+    DELETE: '/hub-managers/:id/delete' as const,
+  },
 }
 
 export default URLS

--- a/server/constants/urls.ts
+++ b/server/constants/urls.ts
@@ -1,6 +1,6 @@
 const URLS = {
   HUB_MANAGERS: {
-    LIST: '/hub-managers' as const,
+    VIEW: '/hub-managers' as const,
     CREATE: '/hub-managers/create' as const,
     DELETE: '/hub-managers/:id/delete' as const,
   },

--- a/server/constants/urls.ts
+++ b/server/constants/urls.ts
@@ -1,0 +1,7 @@
+const URLS = {
+  HUB_MANAGERS__LIST: '/hub-managers' as const,
+  HUB_MANAGERS__CREATE: '/hub-managers/create' as const,
+  HUB_MANAGERS__DELETE: '/hub-managers/:id/delete' as const,
+}
+
+export default URLS

--- a/server/controllers/hubManagers/create.test.ts
+++ b/server/controllers/hubManagers/create.test.ts
@@ -1,4 +1,5 @@
 import logger from '../../../logger'
+import URLS from '../../constants/urls'
 import CrimeMatchingClient from '../../data/crimeMatchingClient'
 import HubManagersService from '../../services/hubManagerService'
 import createMockFile from '../../testutils/createMockFile'
@@ -106,7 +107,7 @@ describe('CreateHubManagerController', () => {
           originalname: 'signature.png',
         }),
       )
-      expect(res.redirect).toHaveBeenCalledWith(303, '/hub-managers')
+      expect(res.redirect).toHaveBeenCalledWith(303, URLS.HUB_MANAGERS__LIST)
     })
   })
 })

--- a/server/controllers/hubManagers/create.test.ts
+++ b/server/controllers/hubManagers/create.test.ts
@@ -107,7 +107,7 @@ describe('CreateHubManagerController', () => {
           originalname: 'signature.png',
         }),
       )
-      expect(res.redirect).toHaveBeenCalledWith(303, URLS.HUB_MANAGERS.LIST)
+      expect(res.redirect).toHaveBeenCalledWith(303, URLS.HUB_MANAGERS.VIEW)
     })
   })
 })

--- a/server/controllers/hubManagers/create.test.ts
+++ b/server/controllers/hubManagers/create.test.ts
@@ -107,7 +107,7 @@ describe('CreateHubManagerController', () => {
           originalname: 'signature.png',
         }),
       )
-      expect(res.redirect).toHaveBeenCalledWith(303, URLS.HUB_MANAGERS__LIST)
+      expect(res.redirect).toHaveBeenCalledWith(303, URLS.HUB_MANAGERS.LIST)
     })
   })
 })

--- a/server/controllers/hubManagers/create.ts
+++ b/server/controllers/hubManagers/create.ts
@@ -16,7 +16,7 @@ export default class CreateHubManagersController {
     const result = await this.hubManagersService.createHubManager(username, name, file)
 
     if (result.ok) {
-      res.redirect(303, URLS.HUB_MANAGERS__LIST)
+      res.redirect(303, URLS.HUB_MANAGERS.LIST)
     } else {
       res.render('pages/hubManagers/create', {
         name,

--- a/server/controllers/hubManagers/create.ts
+++ b/server/controllers/hubManagers/create.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express'
 import HubManagersService from '../../services/hubManagerService'
+import URLS from '../../constants/urls'
 
 export default class CreateHubManagersController {
   constructor(private readonly hubManagersService: HubManagersService) {}
@@ -15,7 +16,7 @@ export default class CreateHubManagersController {
     const result = await this.hubManagersService.createHubManager(username, name, file)
 
     if (result.ok) {
-      res.redirect(303, '/hub-managers')
+      res.redirect(303, URLS.HUB_MANAGERS__LIST)
     } else {
       res.render('pages/hubManagers/create', {
         name,

--- a/server/controllers/hubManagers/create.ts
+++ b/server/controllers/hubManagers/create.ts
@@ -16,7 +16,7 @@ export default class CreateHubManagersController {
     const result = await this.hubManagersService.createHubManager(username, name, file)
 
     if (result.ok) {
-      res.redirect(303, URLS.HUB_MANAGERS.LIST)
+      res.redirect(303, URLS.HUB_MANAGERS.VIEW)
     } else {
       res.render('pages/hubManagers/create', {
         name,

--- a/server/controllers/hubManagers/list.test.ts
+++ b/server/controllers/hubManagers/list.test.ts
@@ -74,7 +74,7 @@ describe('ListHubManagersController', () => {
         expectedAuthOptions,
         'b90f4016-6d0d-4a70-a1ac-a48e43dc48eb',
       )
-      expect(res.redirect).toHaveBeenCalledWith(303, URLS.HUB_MANAGERS.LIST)
+      expect(res.redirect).toHaveBeenCalledWith(303, URLS.HUB_MANAGERS.VIEW)
     })
   })
 })

--- a/server/controllers/hubManagers/list.test.ts
+++ b/server/controllers/hubManagers/list.test.ts
@@ -74,7 +74,7 @@ describe('ListHubManagersController', () => {
         expectedAuthOptions,
         'b90f4016-6d0d-4a70-a1ac-a48e43dc48eb',
       )
-      expect(res.redirect).toHaveBeenCalledWith(303, URLS.HUB_MANAGERS__LIST)
+      expect(res.redirect).toHaveBeenCalledWith(303, URLS.HUB_MANAGERS.LIST)
     })
   })
 })

--- a/server/controllers/hubManagers/list.test.ts
+++ b/server/controllers/hubManagers/list.test.ts
@@ -1,4 +1,5 @@
 import logger from '../../../logger'
+import URLS from '../../constants/urls'
 import CrimeMatchingClient from '../../data/crimeMatchingClient'
 import HubManagersService from '../../services/hubManagerService'
 import createMockRequest from '../../testutils/createMockRequest'
@@ -73,7 +74,7 @@ describe('ListHubManagersController', () => {
         expectedAuthOptions,
         'b90f4016-6d0d-4a70-a1ac-a48e43dc48eb',
       )
-      expect(res.redirect).toHaveBeenCalledWith(303, '/hub-managers')
+      expect(res.redirect).toHaveBeenCalledWith(303, URLS.HUB_MANAGERS__LIST)
     })
   })
 })

--- a/server/controllers/hubManagers/list.ts
+++ b/server/controllers/hubManagers/list.ts
@@ -11,7 +11,7 @@ export default class ListHubManagersController {
 
     await this.hubManagersService.deleteHubManager(username, id)
 
-    res.redirect(303, URLS.HUB_MANAGERS__LIST)
+    res.redirect(303, URLS.HUB_MANAGERS.LIST)
   }
 
   view: RequestHandler = async (req, res) => {

--- a/server/controllers/hubManagers/list.ts
+++ b/server/controllers/hubManagers/list.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express'
 import HubManagersService from '../../services/hubManagerService'
+import URLS from '../../constants/urls'
 
 export default class ListHubManagersController {
   constructor(private readonly hubManagersService: HubManagersService) {}
@@ -10,7 +11,7 @@ export default class ListHubManagersController {
 
     await this.hubManagersService.deleteHubManager(username, id)
 
-    res.redirect(303, '/hub-managers')
+    res.redirect(303, URLS.HUB_MANAGERS__LIST)
   }
 
   view: RequestHandler = async (req, res) => {

--- a/server/controllers/hubManagers/list.ts
+++ b/server/controllers/hubManagers/list.ts
@@ -11,7 +11,7 @@ export default class ListHubManagersController {
 
     await this.hubManagersService.deleteHubManager(username, id)
 
-    res.redirect(303, URLS.HUB_MANAGERS.LIST)
+    res.redirect(303, URLS.HUB_MANAGERS.VIEW)
   }
 
   view: RequestHandler = async (req, res) => {

--- a/server/middleware/populateConstants.test.ts
+++ b/server/middleware/populateConstants.test.ts
@@ -1,0 +1,19 @@
+import createMockRequest from '../testutils/createMockRequest'
+import createMockResponse from '../testutils/createMockResponse'
+import populateConstants from './populateConstants'
+
+describe('populateConstants', () => {
+  it('should populate res.locals with the application constants', () => {
+    // Given
+    const req = createMockRequest()
+    const res = createMockResponse()
+    const next = jest.fn()
+
+    // When
+    populateConstants(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(res.locals.URLS).toBeDefined()
+  })
+})

--- a/server/middleware/populateConstants.ts
+++ b/server/middleware/populateConstants.ts
@@ -1,0 +1,10 @@
+import { RequestHandler } from 'express'
+import URLS from '../constants/urls'
+
+const populateConstants: RequestHandler = (req, res, next) => {
+  res.locals.URLS = URLS
+
+  next()
+}
+
+export default populateConstants

--- a/server/routes/hubManagers.ts
+++ b/server/routes/hubManagers.ts
@@ -10,11 +10,11 @@ const hubManagersRoutes = ({ hubManagersService }: Services): Router => {
   const listController = new ListHubManagersController(hubManagersService)
   const createController = new CreateHubManagersController(hubManagersService)
 
-  router.get(URLS.HUB_MANAGERS__LIST, asyncMiddleware(listController.view))
-  router.post(URLS.HUB_MANAGERS__DELETE, asyncMiddleware(listController.delete))
+  router.get(URLS.HUB_MANAGERS.LIST, asyncMiddleware(listController.view))
+  router.post(URLS.HUB_MANAGERS.DELETE, asyncMiddleware(listController.delete))
 
-  router.get(URLS.HUB_MANAGERS__CREATE, asyncMiddleware(createController.view))
-  router.post(URLS.HUB_MANAGERS__CREATE, asyncMiddleware(createController.submit))
+  router.get(URLS.HUB_MANAGERS.CREATE, asyncMiddleware(createController.view))
+  router.post(URLS.HUB_MANAGERS.CREATE, asyncMiddleware(createController.submit))
 
   return router
 }

--- a/server/routes/hubManagers.ts
+++ b/server/routes/hubManagers.ts
@@ -10,7 +10,7 @@ const hubManagersRoutes = ({ hubManagersService }: Services): Router => {
   const listController = new ListHubManagersController(hubManagersService)
   const createController = new CreateHubManagersController(hubManagersService)
 
-  router.get(URLS.HUB_MANAGERS.LIST, asyncMiddleware(listController.view))
+  router.get(URLS.HUB_MANAGERS.VIEW, asyncMiddleware(listController.view))
   router.post(URLS.HUB_MANAGERS.DELETE, asyncMiddleware(listController.delete))
 
   router.get(URLS.HUB_MANAGERS.CREATE, asyncMiddleware(createController.view))

--- a/server/routes/hubManagers.ts
+++ b/server/routes/hubManagers.ts
@@ -3,17 +3,18 @@ import type { Services } from '../services'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import ListHubManagersController from '../controllers/hubManagers/list'
 import CreateHubManagersController from '../controllers/hubManagers/create'
+import URLS from '../constants/urls'
 
 const hubManagersRoutes = ({ hubManagersService }: Services): Router => {
   const router = Router()
   const listController = new ListHubManagersController(hubManagersService)
   const createController = new CreateHubManagersController(hubManagersService)
 
-  router.get('/', asyncMiddleware(listController.view))
-  router.post('/:id/delete', asyncMiddleware(listController.delete))
+  router.get(URLS.HUB_MANAGERS__LIST, asyncMiddleware(listController.view))
+  router.post(URLS.HUB_MANAGERS__DELETE, asyncMiddleware(listController.delete))
 
-  router.get('/create', asyncMiddleware(createController.view))
-  router.post('/create', asyncMiddleware(createController.submit))
+  router.get(URLS.HUB_MANAGERS__CREATE, asyncMiddleware(createController.view))
+  router.post(URLS.HUB_MANAGERS__CREATE, asyncMiddleware(createController.submit))
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -38,7 +38,7 @@ export default function routes(services: Services): Router {
   router.use('/location-data', locationDataRoutes(services))
   router.use('/police-data', policeDataRoutes(services))
   router.use('/proximity-alert', proximityAlertRoutes(services))
-  router.use('/hub-managers', hubManagersRoutes(services))
+  router.use(hubManagersRoutes(services))
 
   return router
 }

--- a/server/views/pages/hubManagers/list.njk
+++ b/server/views/pages/hubManagers/list.njk
@@ -8,7 +8,7 @@
 
 {% for manager in hubManagers %}
   {% set form %}
-    <form method="post" action="{{ URLS.HUB_MANAGERS__DELETE | replace(':id', manager.id) }}" novalidate>
+    <form method="post" action="{{ URLS.HUB_MANAGERS.DELETE | replace(':id', manager.id) }}" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
       <button class="govuk-link">Delete</button>
     </form>
@@ -43,7 +43,7 @@
   {{
     govukButton({
       text: "Create new manager",
-      href: URLS.HUB_MANAGERS__CREATE
+      href: URLS.HUB_MANAGERS.CREATE
     })
   }}
 

--- a/server/views/pages/hubManagers/list.njk
+++ b/server/views/pages/hubManagers/list.njk
@@ -8,7 +8,7 @@
 
 {% for manager in hubManagers %}
   {% set form %}
-    <form method="post" action="/hub-managers/{{ manager.id }}/delete" novalidate>
+    <form method="post" action="{{ URLS.HUB_MANAGERS__DELETE | replace(':id', manager.id) }}" novalidate>
       <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
       <button class="govuk-link">Delete</button>
     </form>
@@ -43,7 +43,7 @@
   {{
     govukButton({
       text: "Create new manager",
-      href: "/hub-managers/create"
+      href: URLS.HUB_MANAGERS__CREATE
     })
   }}
 


### PR DESCRIPTION
There are many "magic strings" in this repository, for example urls and error messages that are hard-coded and possibly duplicated between views and controllers. It's possible for a magic string to be updated and any duplicate strings missed.

To start, I've grouped the hub manager urls into a single file which can be imported into any router or controller. The urls are also populated in `res.locals` for every request, so are accessible in any view.

If the url is a template, parameters can be replaced in typescript like so:

```ts
URL.HUB_MANAGER.DELETE.replace(':id', manager.id)
```

or in nunjucks (using a builtin filter):

```njk
URLS.HUB_MANAGERS.DELETE | replace(':id', manager.id)
```

Defining the urls using `as const` allows intellisense to display the values if you hover over them anywhere in the app rather than just telling you its a string.