### PR TITLE
Add cypress tests for the manage hub managers area

### DIFF
--- a/integration_tests/e2e/hubManager/create.page.cy.ts
+++ b/integration_tests/e2e/hubManager/create.page.cy.ts
@@ -1,0 +1,85 @@
+import CreateHubManagerPage from '../../pages/hubManagers/create'
+import ListHubManagersPage from '../../pages/hubManagers/list'
+import Page from '../../pages/page'
+
+context('Create Hub Manager', () => {
+  context('Creating a hub manager', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn')
+      cy.signIn()
+      cy.stubGetHubManagers()
+      cy.stubCreateHubManager({
+        status: 201,
+        response: {
+          data: {
+            id: '2cbd9196-3051-4aa1-a5f7-d322ca1b89e7',
+            name: '',
+            hasSignature: true,
+          },
+        },
+      })
+      cy.stubUpdateHubManagerSignature({
+        id: '2cbd9196-3051-4aa1-a5f7-d322ca1b89e7',
+        status: 200,
+        response: {
+          data: {
+            id: '2cbd9196-3051-4aa1-a5f7-d322ca1b89e7',
+            name: '',
+            hasSignature: true,
+          },
+        },
+      })
+    })
+
+    it('should display the create hub manager form', () => {
+      // When the user loads the page
+      cy.visit('/hub-managers/create')
+
+      const page = Page.verifyOnPage(CreateHubManagerPage)
+
+      // Then the form should be visible
+      page.createManagerForm.nameField.element.should('exist')
+      page.createManagerForm.signatureField.element.should('exist')
+      page.createManagerForm.createButton.should('exist')
+    })
+
+    it('should show validation errors if the form is submitted with no data', () => {
+      // When the user loads the page
+      cy.visit('/hub-managers/create')
+
+      let page = Page.verifyOnPage(CreateHubManagerPage)
+
+      // And submits the form
+      page.createManagerForm.createButton.click()
+
+      // Then the page should have reloaded
+      cy.url().should('include', '/hub-managers/create')
+      page = Page.verifyOnPage(CreateHubManagerPage)
+
+      // And should have validation messages
+      page.createManagerForm.nameField.shouldHaveValidationMessage('Enter a name')
+      page.createManagerForm.signatureField.shouldHaveValidationMessage('Upload a file')
+    })
+
+    it('should create a hub manager and redirect to the list', () => {
+      // When the user loads the page
+      cy.visit('/hub-managers/create')
+
+      const page = Page.verifyOnPage(CreateHubManagerPage)
+
+      // And submits the form
+      page.createManagerForm.fillInWith({
+        name: 'Test manager',
+        signature: {
+          contents: 'Test content',
+          fileName: 'signature.png',
+        },
+      })
+      page.createManagerForm.createButton.click()
+
+      // Then the page should redirect to the list
+      Page.verifyOnPage(ListHubManagersPage)
+    })
+  })
+})

--- a/integration_tests/e2e/hubManager/list.page.cy.ts
+++ b/integration_tests/e2e/hubManager/list.page.cy.ts
@@ -1,0 +1,91 @@
+import CreateHubManagerPage from '../../pages/hubManagers/create'
+import ListHubManagersPage from '../../pages/hubManagers/list'
+import Page from '../../pages/page'
+
+context('Create Hub Manager', () => {
+  context('Creating a hub manager', () => {
+    beforeEach(() => {
+      cy.task('reset')
+      cy.task('stubSignIn')
+      cy.signIn()
+    })
+
+    it('should navigate to the create hub managers page', () => {
+      // Given a successful api response
+      cy.stubGetHubManagers()
+
+      // When the user loads the page
+      cy.visit('/hub-managers')
+
+      const page = Page.verifyOnPage(ListHubManagersPage)
+
+      // And clicks the create hub manager button
+      page.createHubManagerButton.click()
+
+      // Then the user should be taken to the create hub manager page
+      Page.verifyOnPage(CreateHubManagerPage)
+    })
+
+    it('should display a list of hub managers', () => {
+      // Given a successful api response
+      cy.stubGetHubManagers({
+        status: 200,
+        response: {
+          data: [
+            {
+              id: '205250b7-c150-410e-8dca-70c170dcec85',
+              name: 'Test manager 1',
+              hasSignature: true,
+            },
+          ],
+        },
+      })
+
+      // When the user loads the page
+      cy.visit('/hub-managers')
+
+      const page = Page.verifyOnPage(ListHubManagersPage)
+
+      // Then the user should be shown a list of hub managers
+      page.dataTable.shouldHaveColumns(['Name', 'Has signature?', 'Actions'])
+      page.dataTable.shouldHaveRows([['Test manager 1', 'true', 'Delete']])
+
+      // And the actions column should have a form to delete the hub manager
+      page.dataTable
+        .cell(0, 2)
+        .find('form')
+        .should('have.attr', 'action', '/hub-managers/205250b7-c150-410e-8dca-70c170dcec85/delete')
+    })
+
+    it('should delete a hub manager', () => {
+      // Given a successful api response
+      cy.stubGetHubManagers({
+        status: 200,
+        response: {
+          data: [
+            {
+              id: '205250b7-c150-410e-8dca-70c170dcec85',
+              name: 'Test manager 1',
+              hasSignature: true,
+            },
+          ],
+        },
+      })
+      cy.stubDeleteHubManager({
+        id: '205250b7-c150-410e-8dca-70c170dcec85',
+        status: 204,
+      })
+
+      // When the user loads the page
+      cy.visit('/hub-managers')
+
+      const page = Page.verifyOnPage(ListHubManagersPage)
+
+      // And the user clicks delete
+      page.dataTable.cell(0, 2).find('form').submit()
+
+      // Then the user should be shown an updated list of hub managers
+      Page.verifyOnPage(ListHubManagersPage)
+    })
+  })
+})

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -7,6 +7,12 @@ import { StubGetIngestionAttemptsOptions } from './mockApis/crimeMatching/ingest
 import { StubGetCrimeMatchingResultsOptions } from './mockApis/crimeMatching/crimeMatchingResults'
 import { StubGetCrimeVersionsOptions } from './mockApis/crimeMatching/crimeVersions'
 import { StubGetCrimeVersionOptions } from './mockApis/crimeMatching/crimeVersion'
+import {
+  StubCreateHubManagerOptions,
+  StubDeleteHubManagerOptions,
+  StubGetHubManagersOptions,
+  StubUpdateHubManagerSignaturesOptions,
+} from './mockApis/crimeMatching/hubManagers'
 
 declare global {
   namespace Cypress {
@@ -46,6 +52,16 @@ declare global {
       signIn(options?: { failOnStatusCode: boolean }): Chainable<AUTWindow>
 
       /**
+       * Stub a wiremock response for the crimeMatchingApi POST /hub-managers
+       */
+      stubCreateHubManager(options?: StubCreateHubManagerOptions): Chainable<void>
+
+      /**
+       * Stub a wiremock response for the crimeMatchingApi POST /hub-managers
+       */
+      stubDeleteHubManager(options?: StubDeleteHubManagerOptions): Chainable<void>
+
+      /**
        * Stub a wiremock response for the crimeMatchingApi POST /crime-batches-query
        */
       stubGetCrimeMatchingResults(options?: StubGetCrimeMatchingResultsOptions): Chainable<void>
@@ -71,6 +87,11 @@ declare global {
       stubGetDeviceActivationPositions(options?: StubGetDeviceActivationPositionsOptions): Chainable<void>
 
       /**
+       * Stub a wiremock response for the crimeMatchingApi GET /hub-managers
+       */
+      stubGetHubManagers(options?: StubGetHubManagersOptions): Chainable<void>
+
+      /**
        * Stub a wiremock response for the crimeMatchingApi GET /ingestion-attempts/{ingestionAttemptId}
        */
       stubGetIngestionAttempt(options?: StubGetIngestionAttemptOptions): Chainable<void>
@@ -94,6 +115,11 @@ declare global {
        * Stub the /os-map/vector/style endpoint to simulate the Ordnance Survey middleware.
        */
       stubMapMiddleware(): Chainable<void>
+
+      /**
+       * Stub a wiremock response for the crimeMatchingApi PUT /hub-managers/{id}/signature
+       */
+      stubUpdateHubManagerSignature(options?: StubUpdateHubManagerSignaturesOptions): Chainable<void>
     }
   }
 }

--- a/integration_tests/mockApis/crimeMatching/hubManagers.ts
+++ b/integration_tests/mockApis/crimeMatching/hubManagers.ts
@@ -1,0 +1,157 @@
+import { stubFor } from '../wiremock'
+
+// Wiremock base path
+const baseUrl = '/crime-matching'
+
+type StubGetHubManagers200Options = {
+  status: 200
+  response: {
+    data: Array<{
+      id: string
+      name: string
+      hasSignature: boolean
+    }>
+  }
+}
+
+type StubGetHubManagersErrorOptions = {
+  status: 404 | 500
+  response: string
+}
+
+type StubGetHubManagersOptions = StubGetHubManagers200Options | StubGetHubManagersErrorOptions
+
+const defaultGetHubManagersOptions: StubGetHubManagersOptions = {
+  status: 200,
+  response: {
+    data: [],
+  },
+}
+
+const stubGetHubManagers = (options: StubGetHubManagersOptions = defaultGetHubManagersOptions) => {
+  return stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `${baseUrl}/hub-managers`,
+    },
+    response: {
+      status: options.status,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: options.response,
+    },
+  })
+}
+
+type StubCreateHubManager200Options = {
+  status: 201
+  response: {
+    data: {
+      id: string
+      name: string
+      hasSignature: boolean
+    }
+  }
+}
+
+type StubCreateHubManagerErrorOptions = {
+  status: 404 | 500
+  response: string
+}
+
+type StubCreateHubManagerOptions = StubCreateHubManager200Options | StubCreateHubManagerErrorOptions
+
+const stubCreateHubManager = (options: StubCreateHubManagerOptions) => {
+  return stubFor({
+    request: {
+      method: 'POST',
+      urlPattern: `${baseUrl}/hub-managers`,
+    },
+    response: {
+      status: options.status,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: options.response,
+    },
+  })
+}
+
+type StubDeleteHubManager204Options = {
+  id: string
+  status: 204
+}
+
+type StubDeleteHubManagerErrorOptions = {
+  id: string
+  status: 404 | 500
+  response: string
+}
+
+type StubDeleteHubManagerOptions = StubDeleteHubManager204Options | StubDeleteHubManagerErrorOptions
+
+const stubDeleteHubManager = (options: StubDeleteHubManagerOptions) => {
+  return stubFor({
+    request: {
+      method: 'DELETE',
+      urlPattern: `${baseUrl}/hub-managers/${options.id}`,
+    },
+    response: {
+      status: options.status,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: options.status === 204 ? undefined : options.response,
+    },
+  })
+}
+
+type StubUpdateHubManagerSignature200Options = {
+  id: string
+  status: 200
+  response: {
+    data: {
+      id: string
+      name: string
+      hasSignature: boolean
+    }
+  }
+}
+
+type StubUpdateHubManagerSignatureErrorOptions = {
+  id: string
+  status: 404 | 500
+  response: string
+}
+
+type StubUpdateHubManagerSignaturesOptions =
+  | StubUpdateHubManagerSignature200Options
+  | StubUpdateHubManagerSignatureErrorOptions
+
+const stubUpdateHubManagerSignature = (options: StubUpdateHubManagerSignaturesOptions) => {
+  return stubFor({
+    request: {
+      method: 'PUT',
+      urlPattern: `${baseUrl}/hub-managers/${options.id}/signature`,
+    },
+    response: {
+      status: options.status,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: options.response,
+    },
+  })
+}
+
+export {
+  stubCreateHubManager,
+  StubCreateHubManagerOptions,
+  stubDeleteHubManager,
+  StubDeleteHubManagerOptions,
+  stubGetHubManagers,
+  StubGetHubManagersOptions,
+  stubUpdateHubManagerSignature,
+  StubUpdateHubManagerSignaturesOptions,
+}

--- a/integration_tests/mockApis/crimeMatching/index.ts
+++ b/integration_tests/mockApis/crimeMatching/index.ts
@@ -8,16 +8,26 @@ import { stubGetIngestionAttempt } from './ingestionAttempt'
 import { stubGetIngestionAttempts } from './ingestionAttempts'
 import { stubGetPerson } from '../locationData/person'
 import { stubGetCrimeVersion } from './crimeVersion'
+import {
+  stubCreateHubManager,
+  stubDeleteHubManager,
+  stubGetHubManagers,
+  stubUpdateHubManagerSignature,
+} from './hubManagers'
 
 export default {
+  stubCreateHubManager,
   stubCrimeMatchingPing: ping,
+  stubDeleteHubManager,
   stubGetCrimeMatchingResults,
   stubGetCrimeVersion,
   stubGetCrimeVersions,
   stubGetDeviceActivation,
   stubGetDeviceActivationPositions,
+  stubGetHubManagers,
   stubGetIngestionAttempt,
   stubGetIngestionAttempts,
   stubGetPersons,
   stubGetPerson,
+  stubUpdateHubManagerSignature,
 }

--- a/integration_tests/pages/components/formFileUploadComponent.ts
+++ b/integration_tests/pages/components/formFileUploadComponent.ts
@@ -1,0 +1,46 @@
+import { v4 as uuidv4 } from 'uuid'
+
+import { PageElement } from '../page'
+
+export type UploadFileOptions = {
+  fileName: string
+  contents: string
+}
+
+export default class FormFileUploadComponent {
+  private elementCacheId: string = uuidv4()
+
+  constructor(
+    private readonly parent: PageElement,
+    private readonly label: string,
+  ) {
+    this.parent
+      .contains('label', this.label)
+      .invoke('attr', 'for')
+      .then(id => cy.get(`#${id}-input`))
+      .as(`${this.elementCacheId}-element`)
+  }
+
+  get element(): PageElement {
+    return cy.get(`@${this.elementCacheId}-element`, { log: false })
+  }
+
+  uploadFile(options: UploadFileOptions): void {
+    this.element.selectFile(
+      {
+        contents: Cypress.Buffer.from(options.contents),
+        fileName: options.fileName,
+        lastModified: Date.now(),
+      },
+      { force: true },
+    )
+  }
+
+  get validationMessage(): PageElement {
+    return this.element.parents('.govuk-form-group').find('.govuk-error-message', { log: false })
+  }
+
+  shouldHaveValidationMessage(message: string): void {
+    this.validationMessage.should('contain', message)
+  }
+}

--- a/integration_tests/pages/components/forms/createHubManagerForm.ts
+++ b/integration_tests/pages/components/forms/createHubManagerForm.ts
@@ -1,0 +1,41 @@
+import { PageElement } from '../../page'
+import FormComponent from '../formComponent'
+import FormFileUploadComponent, { UploadFileOptions } from '../formFileUploadComponent'
+import FormInputComponent from '../formInputComponent'
+
+type CreateHubManagerFormData = {
+  name?: string
+  signature?: UploadFileOptions
+}
+
+export default class CreateHubManagerFormComponent extends FormComponent {
+  constructor() {
+    super('create-hub-managers-form')
+  }
+
+  // FIELDS
+
+  get nameField(): FormInputComponent {
+    return new FormInputComponent(this.form, 'What is the name of the hub manager?')
+  }
+
+  get signatureField(): FormFileUploadComponent {
+    return new FormFileUploadComponent(this.form, 'Upload a signature')
+  }
+
+  get createButton(): PageElement<HTMLButtonElement> {
+    return this.form.contains('button', 'Create')
+  }
+
+  // HELPERS
+
+  fillInWith(data: CreateHubManagerFormData) {
+    if (data.name) {
+      this.nameField.set(data.name)
+    }
+
+    if (data.signature) {
+      this.signatureField.uploadFile(data.signature)
+    }
+  }
+}

--- a/integration_tests/pages/hubManagers/create.ts
+++ b/integration_tests/pages/hubManagers/create.ts
@@ -1,0 +1,12 @@
+import AppPage from '../appPage'
+import CreateHubManagerFormComponent from '../components/forms/createHubManagerForm'
+
+export default class CreateHubManagerPage extends AppPage {
+  constructor() {
+    super('Create hub manager')
+  }
+
+  get createManagerForm(): CreateHubManagerFormComponent {
+    return new CreateHubManagerFormComponent()
+  }
+}

--- a/integration_tests/pages/hubManagers/list.ts
+++ b/integration_tests/pages/hubManagers/list.ts
@@ -1,0 +1,23 @@
+import AppPage from '../appPage'
+import DataTableComponent from '../components/dataTableComponent'
+import { PageElement } from '../page'
+
+export default class ListHubManagersPage extends AppPage {
+  constructor() {
+    super('Hub managers')
+  }
+
+  get createHubManagerButton(): PageElement {
+    return cy.get('a[href="/hub-managers/create"]')
+  }
+
+  get dataTable(): DataTableComponent {
+    return new DataTableComponent()
+  }
+
+  checkOnPage(): void {
+    super.checkOnPage()
+
+    this.createHubManagerButton.should('exist')
+  }
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,4 +1,4 @@
-export type PageElement = Cypress.Chainable<JQuery>
+export type PageElement<TElement = HTMLElement> = Cypress.Chainable<JQuery<TElement>>
 
 export default abstract class Page {
   static verifyOnPage<T extends Page, Args extends unknown[]>(constructor: new (...args: Args) => T, ...args: Args): T {

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -59,6 +59,10 @@ Cypress.Commands.add('stubGetPerson', options => {
   cy.task('stubGetPerson', options)
 })
 
+Cypress.Commands.add('stubUpdateHubManagerSignature', options => {
+  cy.task('stubUpdateHubManagerSignature', options)
+})
+
 Cypress.Commands.add('stubMapMiddleware', () => {
   cy.intercept('GET', '/os-map/vector/style', {
     statusCode: 200,
@@ -73,10 +77,6 @@ Cypress.Commands.add('stubMapMiddleware', () => {
       ],
     },
   }).as('stubMapStyle')
-
-  Cypress.Commands.add('stubUpdateHubManagerSignature', options => {
-    cy.task('stubUpdateHubManagerSignature', options)
-  })
 
   cy.intercept('GET', '/os-map/vector/source', {
     statusCode: 200,

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -11,6 +11,14 @@ Cypress.Commands.add('resetDownloads', path => {
   cy.task('resetDownloads', path)
 })
 
+Cypress.Commands.add('stubCreateHubManager', options => {
+  cy.task('stubCreateHubManager', options)
+})
+
+Cypress.Commands.add('stubDeleteHubManager', options => {
+  cy.task('stubDeleteHubManager', options)
+})
+
 Cypress.Commands.add('stubGetCrimeMatchingResults', options => {
   cy.task('stubGetCrimeMatchingResults', options)
 })
@@ -29,6 +37,10 @@ Cypress.Commands.add('stubGetDeviceActivation', options => {
 
 Cypress.Commands.add('stubGetDeviceActivationPositions', options => {
   cy.task('stubGetDeviceActivationPositions', options)
+})
+
+Cypress.Commands.add('stubGetHubManagers', options => {
+  cy.task('stubGetHubManagers', options)
 })
 
 Cypress.Commands.add('stubGetIngestionAttempt', options => {
@@ -61,6 +73,10 @@ Cypress.Commands.add('stubMapMiddleware', () => {
       ],
     },
   }).as('stubMapStyle')
+
+  Cypress.Commands.add('stubUpdateHubManagerSignature', options => {
+    cy.task('stubUpdateHubManagerSignature', options)
+  })
 
   cy.intercept('GET', '/os-map/vector/source', {
     statusCode: 200,

--- a/server/app.ts
+++ b/server/app.ts
@@ -78,7 +78,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpCurrentUser())
   app.use(populateConstants)
 
-  app.get(
+  app.use(
     '*splat',
     pdsComponents.getPageComponents({
       pdsUrl: config.apis.probationApi.url,

--- a/server/views/pages/hubManagers/create.njk
+++ b/server/views/pages/hubManagers/create.njk
@@ -15,7 +15,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form method="POST" novalidate enctype="multipart/form-data">
+      <form id="create-hub-managers-form" method="POST" novalidate enctype="multipart/form-data">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
         {{


### PR DESCRIPTION
- Caught an issue where the pds header wasn't added to views when `res.render` called in a `POST`.
  - Update the header middleware from `app.get` to `app.use`
 