### PR TITLE
Toggle authorising manager question visibility

### DIFF
--- a/assets/js/components/index.ts
+++ b/assets/js/components/index.ts
@@ -1,7 +1,8 @@
 import MapFocusOnLayer from './map-focus-on-layer'
 import MapLayerVisibilityToggle from './map-layer-visibility-toggle'
+import RevealableContent from './revealable-content'
 import SelectAll from './select-all'
 
-const components = [MapLayerVisibilityToggle, MapFocusOnLayer, SelectAll]
+const components = [MapLayerVisibilityToggle, MapFocusOnLayer, RevealableContent, SelectAll]
 
 export default components

--- a/assets/js/components/revealable-content.ts
+++ b/assets/js/components/revealable-content.ts
@@ -1,0 +1,25 @@
+import { Component } from 'govuk-frontend'
+
+class RevealableContent extends Component {
+  constructor($root: Element) {
+    super($root)
+
+    this.$button.addEventListener('click', _ => this.handleClick())
+  }
+
+  private get $button(): HTMLButtonElement {
+    return this.$root.querySelector("button[type='button']") as HTMLButtonElement
+  }
+
+  private get $content(): HTMLDivElement {
+    return this.$root.querySelector('div.revealable-content__content') as HTMLDivElement
+  }
+
+  private handleClick() {
+    this.$content.classList.toggle('revealable-content__content--hidden')
+  }
+
+  static moduleName = 'revealable-content'
+}
+
+export default RevealableContent

--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -13,6 +13,7 @@ $govuk-page-width: $moj-page-width;
 @import './layouts/map-container';
 @import './components/table';
 @import './components/button';
+@import './components/revealable-content';
 @import './views/location-data/index';
 @import './views/police-data/dashboard';
 @import './local';

--- a/assets/scss/components/_revealable-content.scss
+++ b/assets/scss/components/_revealable-content.scss
@@ -1,0 +1,7 @@
+.revealable-content {
+    .revealable-content__content {
+        &.revealable-content__content--hidden {
+            display: none;
+        }
+    }
+}

--- a/integration_tests/e2e/proximityAlert/crimeVersion.export.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.export.cy.ts
@@ -32,6 +32,7 @@ context('Crime Version', () => {
       let page = Page.verifyOnPage(CrimeVersionPage)
 
       // And clicks export
+      page.exportProximityAlertButton.click()
       page.map.sidebar.exportProximityAlertForm.exportButton.click()
 
       // Then the page should have reloaded
@@ -39,6 +40,8 @@ context('Crime Version', () => {
       page = Page.verifyOnPage(CrimeVersionPage)
 
       // And should have validation messages
+      page.map.sidebar.element.scrollTo('bottom')
+      page.map.sidebar.exportProximityAlertForm.authorisingManagerField.element.should('be.visible')
       page.map.sidebar.exportProximityAlertForm.authorisingManagerField.shouldHaveValidationMessage(
         'Select an authorising manager',
       )

--- a/integration_tests/pages/proximityAlert/crimeVersion.ts
+++ b/integration_tests/pages/proximityAlert/crimeVersion.ts
@@ -15,6 +15,10 @@ export default class CrimeVersionPage extends AppPage {
     return new MapComponent()
   }
 
+  get exportProximityAlertButton(): PageElement<HTMLButtonElement> {
+    return cy.contains('button[type=button]', 'Export proximity alert')
+  }
+
   checkOnPage(): void {
     super.checkOnPage()
 

--- a/server/views/components/revealable-content/macro.njk
+++ b/server/views/components/revealable-content/macro.njk
@@ -1,0 +1,3 @@
+{% macro revealableContent(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/revealable-content/template.njk
+++ b/server/views/components/revealable-content/template.njk
@@ -1,0 +1,15 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+<div class="revealable-content {% if params.classes %}{{ params.classes }}{% endif %}" data-module="revealable-content">
+  {{
+    govukButton({
+      text: params.button.text,
+      classes: params.button.classes,
+      type: "button"
+    })
+  }}
+
+  <div class="revealable-content__content revealable-content__content--hidden">
+    {{ params.content.html | safe | trim | indent(2) }}
+  </div>
+</div>

--- a/server/views/components/revealable-content/template.njk
+++ b/server/views/components/revealable-content/template.njk
@@ -1,5 +1,11 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% if params.content.visible %}
+  {% set contentClasses = "revealable-content__content" %}
+{% else %}
+  {% set contentClasses = "revealable-content__content revealable-content__content--hidden" %}
+{% endif %}
+
 <div class="revealable-content {% if params.classes %}{{ params.classes }}{% endif %}" data-module="revealable-content">
   {{
     govukButton({
@@ -9,7 +15,5 @@
     })
   }}
 
-  <div class="revealable-content__content revealable-content__content--hidden">
-    {{ params.content.html | safe | trim | indent(2) }}
-  </div>
+  <div class="{{ contentClasses }}">{{ params.content.html | safe | trim | indent(2) }}</div>
 </div>

--- a/server/views/pages/proximityAlert/partials/reports.njk
+++ b/server/views/pages/proximityAlert/partials/reports.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "moj/components/alert/macro.njk" import mojAlert %}
+{% from "../../../components/revealable-content/macro.njk" import revealableContent %}
 
 {% set selectedDeviceIds = exportProximityAlertForm.selectedDeviceIds %}
 {% set selectedTrackDeviceIds = exportProximityAlertForm.selectedTrackDeviceIds %}
@@ -185,16 +186,6 @@
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m" />
   {% endfor %}
 
-  <div class="govuk-!-margin-top-4">
-    {{
-      govukButton({
-        text: "Export proximity alert",
-        classes: "govuk-button--secondary govuk-button--full-width",
-        type: "button"
-      })
-    }}
-  </div>
-
   {% set managers = [] %}
 
   {% for manager in hubManagers %}
@@ -211,27 +202,57 @@
     %}
   {% endfor %}
 
+
+  {% set contentHtml %}
+    {{
+      govukRadios({
+        formGroup: {
+          classes: "govuk-!-margin-bottom-6"
+        },
+        fieldset: {
+          legend: {
+            text: "Assign to authorising manager"
+          }
+        },
+        classes: "govuk-radios--small",
+        name: "authorisingManager",
+        errorMessage: errors.authorisingManager,
+        items: managers
+      })
+    }}
+
+    {{
+      govukButton({
+        text: "Export",
+        type: "submit"
+      })
+    }}
+  {% endset %}
+
   {{
-    govukRadios({
-      formGroup: {
-        classes: "govuk-!-margin-bottom-6"
+    revealableContent({
+      button: {
+        text: "Export proximity alert",
+        classes: "govuk-button--secondary govuk-button--full-width"
       },
-      fieldset: {
-        legend: {
-          text: "Assign to authorising manager"
-        }
-      },
-      classes: "govuk-radios--small",
-      name: "authorisingManager",
-      errorMessage: errors.authorisingManager,
-      items: managers
+      classes: "govuk-!-margin-top-4",
+      content: {
+        html: contentHtml
+      }
     })
   }}
 
-  {{
-    govukButton({
-      text: "Export",
-      type: "submit"
-    })
-  }}
+  {# <div class="govuk-!-margin-top-4" data-module="button-reveal">
+    {{
+      govukButton({
+        text: "Export proximity alert",
+        classes: "govuk-button--secondary govuk-button--full-width",
+        type: "button"
+      })
+    }}
+
+    <div class="reveal govuk-tabs__panel--hidden">
+
+    </div>
+  </div> #}
 {% endif %}

--- a/server/views/pages/proximityAlert/partials/reports.njk
+++ b/server/views/pages/proximityAlert/partials/reports.njk
@@ -237,22 +237,9 @@
       },
       classes: "govuk-!-margin-top-4",
       content: {
+        visible: true if errors.authorisingManager,
         html: contentHtml
       }
     })
   }}
-
-  {# <div class="govuk-!-margin-top-4" data-module="button-reveal">
-    {{
-      govukButton({
-        text: "Export proximity alert",
-        classes: "govuk-button--secondary govuk-button--full-width",
-        type: "button"
-      })
-    }}
-
-    <div class="reveal govuk-tabs__panel--hidden">
-
-    </div>
-  </div> #}
 {% endif %}


### PR DESCRIPTION
- Forgot to implement the "Export proximity alert" button that shows the "Authorising Manager" question and "Export" button.
- Implemented a custom component for revealing content, didn't really know what to call it. Tried using the govuk accordion but it doesn't fit our design so custom component it is.
- Because the questions can contain validation errors, the component needs to be configurable to be hidden by default and then shown if there are validation errors.

https://github.com/user-attachments/assets/77fdd79d-5807-44af-b746-8985ecc64f1e

