### PR TITLE
Install chromium in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,14 @@ RUN npm prune --no-audit --no-fund --omit=dev
 # Stage: copy production assets and dependencies
 FROM base
 
+# Chromium is used by playwright for capturing screenshots
+RUN apk add --no-cache \
+        chromium
+
+COPY --from=build --chown=appuser:appgroup \
+        /root/.cache/ms-playwright/chromium_headless_shell-1217 \
+        /home/appuser/.cache/ms-playwright/chromium_headless_shell-1217
+
 COPY --from=build --chown=appuser:appgroup \
         /app/package.json \
         /app/package-lock.json \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,6 @@ RUN apk add --no-cache \
         chromium
 
 COPY --from=build --chown=appuser:appgroup \
-        /root/.cache/ms-playwright/chromium_headless_shell-1217 \
-        /home/appuser/.cache/ms-playwright/chromium_headless_shell-1217
-
-COPY --from=build --chown=appuser:appgroup \
         /app/package.json \
         /app/package-lock.json \
         ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,11 @@ ENV BUILD_NUMBER=${BUILD_NUMBER}
 ENV GIT_REF=${GIT_REF}
 ENV GIT_BRANCH=${GIT_BRANCH}
 
+# Chromium is used by playwright for capturing screenshots
+ENV CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium-browser
+RUN apk add --no-cache \
+        chromium
+
 # Stage: build assets
 FROM base AS build
 
@@ -33,10 +38,6 @@ RUN npm prune --no-audit --no-fund --omit=dev
 
 # Stage: copy production assets and dependencies
 FROM base
-
-# Chromium is used by playwright for capturing screenshots
-RUN apk add --no-cache \
-        chromium
 
 COPY --from=build --chown=appuser:appgroup \
         /app/package.json \

--- a/server/config.ts
+++ b/server/config.ts
@@ -48,6 +48,14 @@ const auditConfig = () => {
   }
 }
 
+const playwrightConfig = () => {
+  const chromiumExecutablePath = get('CHROMIUM_EXECUTABLE_PATH', '')
+
+  return {
+    chromiumExecutablePath: chromiumExecutablePath === '' ? undefined : chromiumExecutablePath,
+  }
+}
+
 export default {
   buildNumber: get('BUILD_NUMBER', '1_0_0', requiredInProduction),
   productId: get('PRODUCT_ID', 'UNASSIGNED', requiredInProduction),
@@ -119,6 +127,7 @@ export default {
   sqs: {
     audit: auditConfig(),
   },
+  playwright: playwrightConfig(),
   ingressUrl: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
 }

--- a/server/services/proximityAlert/playwrightBrowserService.ts
+++ b/server/services/proximityAlert/playwrightBrowserService.ts
@@ -1,5 +1,6 @@
 import { chromium, type Browser } from 'playwright'
 import logger from '../../../logger'
+import config from '../../config'
 
 export default class PlaywrightBrowserService {
   private browser?: Browser
@@ -13,9 +14,15 @@ export default class PlaywrightBrowserService {
     this.launching = (async () => {
       try {
         logger.info('[playwright] launching shared browser')
-        const chromiumBrowser = await chromium.launch({ headless: true })
+        const chromiumBrowser = await chromium.launch({
+          executablePath: config.playwright.chromiumExecutablePath,
+          headless: true,
+        })
         this.browser = chromiumBrowser
         return chromiumBrowser
+      } catch (e) {
+        logger.error(e)
+        throw e
       } finally {
         this.launching = undefined
       }


### PR DESCRIPTION
## Why do we need to install chromium?

The UI container is built from a base alpine [image](https://github.com/ministryofjustice/hmpps-base-container-images/blob/main/images/node/alpine/Dockerfile). Playwright doesn't support the alpine distribution. See [docs](https://playwright.dev/docs/docker#alpine).
> Browser builds for Firefox and WebKit are built for the [glibc](https://en.wikipedia.org/wiki/Glibc) library. Alpine Linux and other distributions that are based on the [musl](https://en.wikipedia.org/wiki/Musl) standard library are not supported.

This means if we try to do `npx playwright install --with-deps chromium` it will fail - specifically it tries to fall back to installing the ubuntu deps using `apt-get` which doesn't exist in alpine.

Playwright does warn that it only works with bundled Chromium, this appears to be due to possible version mismatches between the system chromium and playwright. At the moment we believe this risk to be low as we're only doing some simple screenshotting.

> Note that Playwright only works with the bundled Chromium, Firefox or WebKit, use at your own risk.

## Why do we need a `playwrightConfig`?

When creating a chromium browser, the executable path can be set:
```ts
const chromiumBrowser = await chromium.launch({
  executablePath: config.playwright.chromiumExecutablePath,
  headless: true,
})
```
`executablePath` has the type: `string | undefined`.

So it makes sense to make `config.playwright.chromiumExecutablePath` have the same type. But annoyingly the `get<T>` config method doesn't allow you to return `undefined`. So to get around this, I've wrapped it in a simple helper that allows `chromiumExecutablePath` to be `string | undefined`.

When running locally, `CHROMIUM_EXECUTABLE_PATH` can be left unset and it should use the bundled Chromium. N.B. `CHROMIUM_EXECUTABLE_PATH` is set in the `Dockerfile` so does not need to set in any other environment config.