### PR TITLE
ACR 743 fail app on playwright failure

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/values.yaml
@@ -23,7 +23,7 @@ generic-service:
 
   readinessProbe:
     httpGet:
-      path: /ping
+      path: /readiness
 
   # Environment variables to load into the deployment
   env:
@@ -74,4 +74,3 @@ generic-prometheus-alerts:
 # Override in values-dev.yaml
 # Also update the environment variables to point the application to the mocked services (on port 80)
 deploy_stubs: false
-

--- a/helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/values.yaml
@@ -17,14 +17,6 @@ generic-service:
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-electronic-monitoring-crime-matching-cert
 
-  livenessProbe:
-    httpGet:
-      path: /ping
-
-  readinessProbe:
-    httpGet:
-      path: /readiness
-
   # Environment variables to load into the deployment
   env:
     NODE_ENV: 'production'

--- a/integration_tests/e2e/health.cy.ts
+++ b/integration_tests/e2e/health.cy.ts
@@ -9,7 +9,17 @@ context('Healthcheck', () => {
     })
 
     it('Health check page is visible and UP', () => {
-      cy.request('/health').its('body.status').should('equal', 'UP')
+      cy.request('/health').then(response => {
+        expect(response.body.status).to.equal('UP')
+        expect(response.body.components.playwright.status).to.equal('UP')
+      })
+    })
+
+    it('Readiness check is visible and UP', () => {
+      cy.request('/readiness').then(response => {
+        expect(response.body.status).to.equal('UP')
+        expect(response.body.components.playwright.status).to.equal('UP')
+      })
     })
 
     it('Ping is visible and UP', () => {
@@ -37,11 +47,19 @@ context('Healthcheck', () => {
         expect(response.body.components.tokenVerification.details).to.contain({ status: 500, attempts: 3 })
         expect(response.body.components.crimeMatchingApi.status).to.equal('UP')
         expect(response.body.components.probationApi.status).to.equal('DOWN')
+        expect(response.body.components.playwright.status).to.equal('UP')
       })
     })
 
     it('Health check page is visible and DOWN', () => {
       cy.request({ url: '/health', method: 'GET', failOnStatusCode: false }).its('body.status').should('equal', 'DOWN')
+    })
+
+    it('Readiness check remains UP when APIs are unhealthy', () => {
+      cy.request('/readiness').then(response => {
+        expect(response.body.status).to.equal('UP')
+        expect(response.body.components.playwright.status).to.equal('UP')
+      })
     })
   })
 })

--- a/integration_tests/e2e/health.cy.ts
+++ b/integration_tests/e2e/health.cy.ts
@@ -16,10 +16,14 @@ context('Healthcheck', () => {
     })
 
     it('Readiness check is visible and UP', () => {
-      cy.request('/readiness').then(response => {
+      cy.request('/health/readiness').then(response => {
         expect(response.body.status).to.equal('UP')
         expect(response.body.components.playwright.status).to.equal('UP')
       })
+    })
+
+    it('Liveness check is visible and UP', () => {
+      cy.request('/health/liveness').its('body.status').should('equal', 'UP')
     })
 
     it('Ping is visible and UP', () => {
@@ -56,7 +60,7 @@ context('Healthcheck', () => {
     })
 
     it('Readiness check remains UP when APIs are unhealthy', () => {
-      cy.request('/readiness').then(response => {
+      cy.request('health/readiness').then(response => {
         expect(response.body.status).to.equal('UP')
         expect(response.body.components.playwright.status).to.equal('UP')
       })

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open --e2e --browser chrome",
+    "int-test-init:ci": "npx playwright install --with-deps chromium",
     "clean": "rm -rf dist test_results",
     "rebuild": "npm run clean && npm run setup && npm run build",
     "setup": "npm ci && hmpps-npm-script-run-allowlist"

--- a/server.ts
+++ b/server.ts
@@ -17,12 +17,8 @@ dayjs.extend(isSameOrAfter)
 dayjs.extend(isSameOrBefore)
 
 async function start(): Promise<void> {
-  try {
-    await services.playwrightBrowserService.getBrowser()
-    logger.info('[playwright] browser launched at startup')
-  } catch (error) {
-    logger.error({ error }, '[playwright] failed to launch browser at startup')
-  }
+  await services.playwrightBrowserService.getBrowser()
+  logger.info('[playwright] browser launched at startup')
 
   const port = app.get('port')
 
@@ -39,7 +35,7 @@ async function start(): Promise<void> {
         await services.playwrightBrowserService.close()
         logger.info('[playwright] browser closed')
       } catch (error) {
-        logger.warn({ error }, '[playwright] error closing browser')
+        logger.warn(error, '[playwright] error closing browser')
       }
 
       process.exit(0)
@@ -49,7 +45,7 @@ async function start(): Promise<void> {
   // Listen for termination signals to allow for graceful shutdown
   process.on('SIGTERM', () => {
     shutdown('SIGTERM').catch(error => {
-      logger.error({ error }, 'SIGTERM shutdown failed')
+      logger.error(error, 'SIGTERM shutdown failed')
       process.exit(1)
     })
   })
@@ -57,7 +53,7 @@ async function start(): Promise<void> {
   // Also listen for SIGINT (e.g. Ctrl+C) to allow for graceful shutdown in development
   process.on('SIGINT', () => {
     shutdown('SIGINT').catch(error => {
-      logger.error({ error }, 'SIGINT shutdown failed')
+      logger.error(error, 'SIGINT shutdown failed')
       process.exit(1)
     })
   })
@@ -65,6 +61,6 @@ async function start(): Promise<void> {
 
 // Start the server
 start().catch(error => {
-  logger.error({ error }, 'Startup failed')
+  logger.error(error, '[playwright] failed to launch browser at startup')
   process.exit(1)
 })

--- a/server/app.ts
+++ b/server/app.ts
@@ -65,7 +65,7 @@ export default function createApp(services: Services): express.Application {
   )
 
   app.use(appInsightsMiddleware())
-  app.use(setUpHealthChecks(services.applicationInfo))
+  app.use(setUpHealthChecks(services.applicationInfo, services.playwrightBrowserService))
   app.use(setUpWebSecurity())
   app.use(setUpWebSession())
   app.use(setUpWebRequestParsing())

--- a/server/middleware/setUpHealthChecks.ts
+++ b/server/middleware/setUpHealthChecks.ts
@@ -36,7 +36,9 @@ export default function setUpHealthChecks(
     ],
   })
 
-  router.get('/readiness', async (_req, res, next) => {
+  router.get('/health/liveness', middleware.ping)
+
+  router.get('/health/readiness', async (_req, res, next) => {
     try {
       const playwrightHealth = await playwrightHealthComponent.health()
 

--- a/server/middleware/setUpHealthChecks.ts
+++ b/server/middleware/setUpHealthChecks.ts
@@ -1,18 +1,54 @@
 import express, { Router } from 'express'
-
-import { monitoringMiddleware, endpointHealthComponent } from '@ministryofjustice/hmpps-monitoring'
+import {
+  monitoringMiddleware,
+  endpointHealthComponent,
+  type HealthComponent,
+  type ComponentHealthResult,
+} from '@ministryofjustice/hmpps-monitoring'
 import type { ApplicationInfo } from '../applicationInfo'
+import type PlaywrightBrowserService from '../services/proximityAlert/playwrightBrowserService'
 import logger from '../../logger'
 import config from '../config'
 
-export default function setUpHealthChecks(applicationInfo: ApplicationInfo): Router {
+const playwrightComponent = (playwrightBrowserService: PlaywrightBrowserService): HealthComponent => ({
+  isEnabled: () => true,
+
+  health: async (): Promise<ComponentHealthResult> => ({
+    name: 'playwright',
+    status: playwrightBrowserService.isReady() ? 'UP' : 'DOWN',
+  }),
+})
+
+export default function setUpHealthChecks(
+  applicationInfo: ApplicationInfo,
+  playwrightBrowserService: PlaywrightBrowserService,
+): Router {
   const router = express.Router()
 
   const apiConfig = Object.entries(config.apis)
+  const playwrightHealthComponent = playwrightComponent(playwrightBrowserService)
 
   const middleware = monitoringMiddleware({
     applicationInfo,
-    healthComponents: apiConfig.map(([name, options]) => endpointHealthComponent(logger, name, options)),
+    healthComponents: [
+      ...apiConfig.map(([name, options]) => endpointHealthComponent(logger, name, options)),
+      playwrightHealthComponent,
+    ],
+  })
+
+  router.get('/readiness', async (_req, res, next) => {
+    try {
+      const playwrightHealth = await playwrightHealthComponent.health()
+
+      return res.status(playwrightHealth.status === 'UP' ? 200 : 503).json({
+        status: playwrightHealth.status,
+        components: {
+          [playwrightHealth.name]: { status: playwrightHealth.status },
+        },
+      })
+    } catch (error) {
+      return next(error)
+    }
   })
 
   router.get('/health', middleware.health)

--- a/server/services/proximityAlert/playwrightBrowserService.test.ts
+++ b/server/services/proximityAlert/playwrightBrowserService.test.ts
@@ -1,0 +1,117 @@
+import { chromium, type Browser } from 'playwright'
+import PlaywrightBrowserService from './playwrightBrowserService'
+
+// Silence logger during tests
+jest.mock('../../../logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}))
+
+jest.mock('playwright', () => ({
+  chromium: {
+    launch: jest.fn(),
+  },
+}))
+
+describe('PlaywrightBrowserService', () => {
+  const launchMock = chromium.launch as jest.Mock
+
+  const createBrowser = (isConnected = true): Browser =>
+    ({
+      isConnected: jest.fn(() => isConnected),
+      close: jest.fn(),
+      on: jest.fn(),
+    }) as unknown as Browser
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('launches chromium when no browser exists', async () => {
+    const browser = createBrowser()
+    launchMock.mockResolvedValue(browser)
+
+    const service = new PlaywrightBrowserService()
+
+    await expect(service.getBrowser()).resolves.toBe(browser)
+
+    expect(launchMock).toHaveBeenCalledWith({
+      executablePath: undefined,
+      headless: true,
+    })
+  })
+
+  it('reuses an existing connected browser', async () => {
+    const browser = createBrowser()
+    launchMock.mockResolvedValue(browser)
+
+    const service = new PlaywrightBrowserService()
+
+    await service.getBrowser()
+    const secondBrowser = await service.getBrowser()
+
+    expect(secondBrowser).toBe(browser)
+    expect(launchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('two simultaneous calls only trigger one browser launch', async () => {
+    const browser = createBrowser()
+    launchMock.mockResolvedValue(browser)
+
+    const service = new PlaywrightBrowserService()
+
+    const [firstBrowser, secondBrowser] = await Promise.all([service.getBrowser(), service.getBrowser()])
+
+    expect(firstBrowser).toBe(browser)
+    expect(secondBrowser).toBe(browser)
+    expect(launchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports ready when the browser is connected', async () => {
+    const browser = createBrowser(true)
+    launchMock.mockResolvedValue(browser)
+
+    const service = new PlaywrightBrowserService()
+
+    expect(service.isReady()).toBe(false)
+
+    await service.getBrowser()
+
+    expect(service.isReady()).toBe(true)
+  })
+
+  it('reports not ready when the browser is disconnected', async () => {
+    const browser = createBrowser(false)
+    launchMock.mockResolvedValue(browser)
+
+    const service = new PlaywrightBrowserService()
+
+    await service.getBrowser()
+
+    expect(service.isReady()).toBe(false)
+  })
+
+  it('closes the browser and clears readiness', async () => {
+    const browser = createBrowser()
+    launchMock.mockResolvedValue(browser)
+
+    const service = new PlaywrightBrowserService()
+
+    await service.getBrowser()
+    await service.close()
+
+    expect(browser.close).toHaveBeenCalled()
+    expect(service.isReady()).toBe(false)
+  })
+
+  it('rejects when chromium fails to launch', async () => {
+    const launchError = new Error('Chromium failed to launch')
+    launchMock.mockRejectedValue(launchError)
+
+    const service = new PlaywrightBrowserService()
+
+    await expect(service.getBrowser()).rejects.toThrow('Chromium failed to launch')
+    expect(service.isReady()).toBe(false)
+  })
+})

--- a/server/services/proximityAlert/playwrightBrowserService.ts
+++ b/server/services/proximityAlert/playwrightBrowserService.ts
@@ -8,7 +8,7 @@ export default class PlaywrightBrowserService {
   private launching?: Promise<Browser>
 
   async getBrowser(): Promise<Browser> {
-    if (this.browser) return this.browser
+    if (this.browser?.isConnected()) return this.browser
     if (this.launching) return this.launching
 
     this.launching = (async () => {
@@ -18,17 +18,27 @@ export default class PlaywrightBrowserService {
           executablePath: config.playwright.chromiumExecutablePath,
           headless: true,
         })
+
+        chromiumBrowser.on('disconnected', () => {
+          logger.error('[playwright] shared browser disconnected')
+
+          if (this.browser === chromiumBrowser) {
+            this.browser = undefined
+          }
+        })
+
         this.browser = chromiumBrowser
         return chromiumBrowser
-      } catch (e) {
-        logger.error(e)
-        throw e
       } finally {
         this.launching = undefined
       }
     })()
 
     return this.launching
+  }
+
+  isReady(): boolean {
+    return Boolean(this.browser?.isConnected())
   }
 
   async close(): Promise<void> {


### PR DESCRIPTION
### Initialise and enforce Playwright browser availability across environments

The application should now:

- launch a shared Playwright Chromium browser during startup
- fail startup if Chromium cannot be launched
- add a dedicated /readiness endpoint for Kubernetes readiness checks, making sure Playwright is operational or it will fail
- close the shared browser during graceful shutdown

I created a new /readiness endpoint rather than use /health as some other repos do, otherwise using

```
readinessProbe: 
    httpGet: 
        path: /health 
```

would have failed the app if any APIs were down, which I assume we don't want?