### PR TITLE
Fix playwright flakiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open --e2e --browser chrome",
-    "int-test-init:ci": "npx playwright install chromium",
+    "int-test-init:ci": "npx playwright install",
     "clean": "rm -rf dist test_results",
     "rebuild": "npm run clean && npm run setup && npm run build",
     "setup": "npm ci && hmpps-npm-script-run-allowlist"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open --e2e --browser chrome",
-    "int-test-init:ci": "npx playwright install --with-deps chromium",
+    "int-test-init:ci": "npx playwright install chromium",
     "clean": "rm -rf dist test_results",
     "rebuild": "npm run clean && npm run setup && npm run build",
     "setup": "npm ci && hmpps-npm-script-run-allowlist"


### PR DESCRIPTION
The `npm run int-test-init:ci` step get hanging during installation - not really sure why. This updates the command to match the typescript-template repo which seems to work.