### PR TITLE
Protect hub managers routes

### DIFF
--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -8,7 +8,7 @@ export default function createErrorHandler(production: boolean) {
 
     if (error.status === 401 || error.status === 403) {
       logger.info('Logging user out')
-      return res.redirect('/sign-out')
+      return res.status(error.status).render('pages/notAuthorised')
     }
 
     res.locals.message = production

--- a/server/middleware/hasRole.ts
+++ b/server/middleware/hasRole.ts
@@ -2,14 +2,14 @@ import { RequestHandler } from 'express'
 import createHttpError from 'http-errors'
 import { Role } from '../constants/roles'
 
-const hasAnyRole =
-  (roles: Array<Role>): RequestHandler =>
+const hasRole =
+  (role: Role): RequestHandler =>
   (req, res, next) => {
-    if (res.locals.user.userRoles.some(role => (roles as Array<string>).includes(role))) {
+    if (res.locals.user.userRoles.includes(role)) {
       next()
     } else {
       next(createHttpError(403, 'Unauthorised'))
     }
   }
 
-export default hasAnyRole
+export default hasRole

--- a/server/routes/hubManagers.test.ts
+++ b/server/routes/hubManagers.test.ts
@@ -1,4 +1,5 @@
 import request from 'supertest'
+import { randomUUID } from 'crypto'
 import { appWithAllRoutes, hubCaseworker, hubManager } from './testutils/appSetup'
 import logger from '../../logger'
 import CrimeMatchingClient from '../data/crimeMatchingClient'
@@ -7,7 +8,14 @@ import HubManagersService from '../services/hubManagerService'
 jest.mock('../data/crimeMatchingClient')
 jest.mock('../../logger')
 
-describe('/location-data', () => {
+const authorisingManager = {
+  id: 'a6e61168-f7ca-4056-8a2d-7db0fd77fb62',
+  name: 'Test manager 1',
+  occupation: 'MoJ EM Hub Manager',
+  hasSignature: true,
+}
+
+describe('/hub-managers', () => {
   let restClient: jest.Mocked<CrimeMatchingClient>
 
   beforeEach(() => {
@@ -20,11 +28,7 @@ describe('/location-data', () => {
 
   describe('GET /hub-managers', () => {
     it('should return a 403 if the user is a caseworker', () => {
-      const hubManagersService = new HubManagersService(restClient)
       const app = appWithAllRoutes({
-        services: {
-          hubManagersService,
-        },
         userSupplier: () => hubCaseworker,
       })
 
@@ -57,6 +61,109 @@ describe('/location-data', () => {
           expect(res.status).toEqual(200)
           expect(res.text).toContain('Hub managers')
         })
+    })
+  })
+
+  describe('GET /hub-managers/create', () => {
+    it('should return a 403 if the user is a caseworker', () => {
+      const app = appWithAllRoutes({
+        userSupplier: () => hubCaseworker,
+      })
+
+      return request(app)
+        .get('/hub-managers/create')
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.status).toEqual(403)
+          expect(res.text).toContain('You do not have permission to complete this action')
+        })
+    })
+
+    it('should return a 200 if the user is a manager', () => {
+      const app = appWithAllRoutes({
+        userSupplier: () => hubManager,
+      })
+
+      return request(app)
+        .get('/hub-managers/create')
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.status).toEqual(200)
+          expect(res.text).toContain('Create hub manager')
+        })
+    })
+  })
+
+  describe('POST /hub-managers/create', () => {
+    it('should return a 403 if the user is a caseworker', () => {
+      const app = appWithAllRoutes({
+        userSupplier: () => hubCaseworker,
+      })
+
+      return request(app)
+        .post('/hub-managers/create')
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.status).toEqual(403)
+          expect(res.text).toContain('You do not have permission to complete this action')
+        })
+    })
+
+    it('should return a 303 if the user is a manager', () => {
+      const hubManagersService = new HubManagersService(restClient)
+      const app = appWithAllRoutes({
+        services: {
+          hubManagersService,
+        },
+        userSupplier: () => hubManager,
+      })
+
+      restClient.createHubManager.mockResolvedValue({ data: authorisingManager })
+      restClient.updateHubManagerSignature.mockResolvedValue({ data: authorisingManager })
+
+      return request(app)
+        .post('/hub-managers/create')
+        .field('name', 'Test')
+        .attach('file', Buffer.from('content'), 'image.png')
+        .expect('Content-Type', /text\/plain/)
+        .expect(303)
+        .expect('Location', '/hub-managers')
+    })
+  })
+
+  describe('POST /hub-managers/{id}/delete', () => {
+    it('should return a 403 if the user is a caseworker', () => {
+      const id = randomUUID()
+      const app = appWithAllRoutes({
+        userSupplier: () => hubCaseworker,
+      })
+
+      return request(app)
+        .post(`/hub-managers/${id}/delete`)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.status).toEqual(403)
+          expect(res.text).toContain('You do not have permission to complete this action')
+        })
+    })
+
+    it('should return a 303 if the user is a manager', () => {
+      const id = randomUUID()
+      const hubManagersService = new HubManagersService(restClient)
+      const app = appWithAllRoutes({
+        services: {
+          hubManagersService,
+        },
+        userSupplier: () => hubManager,
+      })
+
+      restClient.deleteHubManager.mockResolvedValue({})
+
+      return request(app)
+        .post(`/hub-managers/${id}/delete`)
+        .expect('Content-Type', /text\/plain/)
+        .expect(303)
+        .expect('Location', '/hub-managers')
     })
   })
 })

--- a/server/routes/hubManagers.test.ts
+++ b/server/routes/hubManagers.test.ts
@@ -1,0 +1,62 @@
+import request from 'supertest'
+import { appWithAllRoutes, hubCaseworker, hubManager } from './testutils/appSetup'
+import logger from '../../logger'
+import CrimeMatchingClient from '../data/crimeMatchingClient'
+import HubManagersService from '../services/hubManagerService'
+
+jest.mock('../data/crimeMatchingClient')
+jest.mock('../../logger')
+
+describe('/location-data', () => {
+  let restClient: jest.Mocked<CrimeMatchingClient>
+
+  beforeEach(() => {
+    restClient = new CrimeMatchingClient(logger) as jest.Mocked<CrimeMatchingClient>
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('GET /hub-managers', () => {
+    it('should return a 403 if the user is a caseworker', () => {
+      const hubManagersService = new HubManagersService(restClient)
+      const app = appWithAllRoutes({
+        services: {
+          hubManagersService,
+        },
+        userSupplier: () => hubCaseworker,
+      })
+
+      return request(app)
+        .get('/hub-managers')
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.status).toEqual(403)
+          expect(res.text).toContain('You do not have permission to complete this action')
+        })
+    })
+
+    it('should return a 200 if the user is a manager', () => {
+      const hubManagersService = new HubManagersService(restClient)
+      const app = appWithAllRoutes({
+        services: {
+          hubManagersService,
+        },
+        userSupplier: () => hubManager,
+      })
+
+      restClient.getHubManagers.mockResolvedValue({
+        data: [],
+      })
+
+      return request(app)
+        .get('/hub-managers')
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.status).toEqual(200)
+          expect(res.text).toContain('Hub managers')
+        })
+    })
+  })
+})

--- a/server/routes/hubManagers.ts
+++ b/server/routes/hubManagers.ts
@@ -5,14 +5,14 @@ import ListHubManagersController from '../controllers/hubManagers/list'
 import CreateHubManagersController from '../controllers/hubManagers/create'
 import URLS from '../constants/urls'
 import { ROLES } from '../constants/roles'
-import hasAnyRole from '../utils/auth'
+import hasRole from '../middleware/hasRole'
 
 const hubManagersRoutes = ({ hubManagersService }: Services): Router => {
   const router = Router()
   const listController = new ListHubManagersController(hubManagersService)
   const createController = new CreateHubManagersController(hubManagersService)
 
-  router.use('/hub-managers', hasAnyRole([ROLES.CRIME_MATCHING_HUB_MANAGER]))
+  router.use('/hub-managers', hasRole(ROLES.CRIME_MATCHING_HUB_MANAGER))
 
   router.get(URLS.HUB_MANAGERS.VIEW, asyncMiddleware(listController.view))
   router.post(URLS.HUB_MANAGERS.DELETE, asyncMiddleware(listController.delete))

--- a/server/routes/hubManagers.ts
+++ b/server/routes/hubManagers.ts
@@ -12,7 +12,7 @@ const hubManagersRoutes = ({ hubManagersService }: Services): Router => {
   const listController = new ListHubManagersController(hubManagersService)
   const createController = new CreateHubManagersController(hubManagersService)
 
-  router.use('/hub-managers', hasRole(ROLES.CRIME_MATCHING_HUB_MANAGER))
+  router.use(URLS.HUB_MANAGERS.VIEW, hasRole(ROLES.CRIME_MATCHING_HUB_MANAGER))
 
   router.get(URLS.HUB_MANAGERS.VIEW, asyncMiddleware(listController.view))
   router.post(URLS.HUB_MANAGERS.DELETE, asyncMiddleware(listController.delete))

--- a/server/routes/hubManagers.ts
+++ b/server/routes/hubManagers.ts
@@ -4,11 +4,15 @@ import asyncMiddleware from '../middleware/asyncMiddleware'
 import ListHubManagersController from '../controllers/hubManagers/list'
 import CreateHubManagersController from '../controllers/hubManagers/create'
 import URLS from '../constants/urls'
+import { ROLES } from '../constants/roles'
+import hasAnyRole from '../utils/auth'
 
 const hubManagersRoutes = ({ hubManagersService }: Services): Router => {
   const router = Router()
   const listController = new ListHubManagersController(hubManagersService)
   const createController = new CreateHubManagersController(hubManagersService)
+
+  router.use('/hub-managers', hasAnyRole([ROLES.CRIME_MATCHING_HUB_MANAGER]))
 
   router.get(URLS.HUB_MANAGERS.VIEW, asyncMiddleware(listController.view))
   router.post(URLS.HUB_MANAGERS.DELETE, asyncMiddleware(listController.delete))

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -1,6 +1,6 @@
 import type { Express } from 'express'
 import request from 'supertest'
-import { appWithAllRoutes, user } from './testutils/appSetup'
+import { appWithAllRoutes, hubCaseworker } from './testutils/appSetup'
 import AuditService, { Page } from '../services/auditService'
 import HmppsAuditClient from '../data/hmppsAuditClient'
 import FeaturesService from '../services/featuresService'
@@ -26,7 +26,7 @@ beforeEach(() => {
       auditService,
       featuresService,
     },
-    userSupplier: () => user,
+    userSupplier: () => hubCaseworker,
   })
 })
 
@@ -44,7 +44,7 @@ describe('GET /', () => {
       .expect(res => {
         expect(res.text).toContain('Crime matching tool')
         expect(auditService.logPageView).toHaveBeenCalledWith(Page.HOMEPAGE, {
-          who: user.username,
+          who: hubCaseworker.username,
           correlationId: expect.any(String),
         })
       })

--- a/server/routes/location-data.test.ts
+++ b/server/routes/location-data.test.ts
@@ -1,5 +1,5 @@
 import request from 'supertest'
-import { appWithAllRoutes, user } from './testutils/appSetup'
+import { appWithAllRoutes } from './testutils/appSetup'
 import logger from '../../logger'
 import DeviceActivationsService from '../services/deviceActivationsService'
 import ValidationService from '../services/locationData/validationService'
@@ -31,7 +31,6 @@ describe('/location-data', () => {
           personsService,
           validationService,
         },
-        userSupplier: () => user,
       })
 
       return request(app)
@@ -54,7 +53,6 @@ describe('/location-data', () => {
           personsService,
           validationService,
         },
-        userSupplier: () => user,
       })
 
       restClient.getDeviceActivation.mockRejectedValue({
@@ -84,7 +82,6 @@ describe('/location-data', () => {
           personsService,
           validationService,
         },
-        userSupplier: () => user,
       })
 
       restClient.getDeviceActivation.mockResolvedValueOnce({

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -7,6 +7,7 @@ import timezone from 'dayjs/plugin/timezone'
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
 
+import multer from 'multer'
 import routes from '../index'
 import nunjucksSetup from '../../utils/nunjucksSetup'
 import errorHandler from '../../errorHandler'
@@ -71,6 +72,7 @@ function appSetup(services: Services, production: boolean, userSupplier: () => H
   })
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
+  app.use(multer().single('file'))
   app.use(routes(services))
   app.use((req, res, next) => next(new NotFound()))
   app.use(errorHandler(production))

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -15,6 +15,7 @@ import AuditService from '../../services/auditService'
 import { HmppsUser } from '../../interfaces/hmppsUser'
 import setUpWebSession from '../../middleware/setUpWebSession'
 import HmppsAuditClient from '../../data/hmppsAuditClient'
+import { ROLES } from '../../constants/roles'
 
 jest.mock('../../services/auditService')
 jest.mock('../../data/hmppsAuditClient')
@@ -24,7 +25,7 @@ dayjs.extend(timezone)
 dayjs.extend(isSameOrAfter)
 dayjs.extend(isSameOrBefore)
 
-export const user: HmppsUser = {
+export const hubCaseworker: HmppsUser = {
   name: 'FIRST LAST',
   userId: 'id',
   token: 'token',
@@ -32,7 +33,12 @@ export const user: HmppsUser = {
   displayName: 'First Last',
   authSource: 'nomis',
   staffId: 1234,
-  userRoles: [],
+  userRoles: [ROLES.CRIME_MATCHING_HUB_CASEWORKER],
+}
+
+export const hubManager: HmppsUser = {
+  ...hubCaseworker,
+  userRoles: [ROLES.CRIME_MATCHING_HUB_MANAGER],
 }
 
 const hmppsAuditClient = new HmppsAuditClient({
@@ -77,7 +83,7 @@ export function appWithAllRoutes({
   services = {
     auditService: new AuditService(hmppsAuditClient) as jest.Mocked<AuditService>,
   },
-  userSupplier = () => user,
+  userSupplier = () => hubCaseworker,
 }: {
   production?: boolean
   services?: Partial<Services>

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -1,0 +1,15 @@
+import { RequestHandler } from 'express'
+import createHttpError from 'http-errors'
+import { Role } from '../constants/roles'
+
+const hasAnyRole =
+  (roles: Array<Role>): RequestHandler =>
+  (req, res, next) => {
+    if (res.locals.user.userRoles.some(role => (roles as Array<string>).includes(role))) {
+      next()
+    } else {
+      next(createHttpError(403, 'Unauthorised'))
+    }
+  }
+
+export default hasAnyRole

--- a/server/views/pages/notAuthorised.njk
+++ b/server/views/pages/notAuthorised.njk
@@ -1,0 +1,11 @@
+{% extends "partials/layout.njk" %}
+
+{% set pageTitle = "Not Authorised - " + applicationName %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">You do not have permission to complete this action.</h1>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
- Updates the error handler to display an error page when the user is not authorised to perform an action rather than logging them out.
- Add a middleware util for protecting individual routes or sub routers.
- Opted to not use `hasRole` on every route (for now) as we check the user is a manager or casework for every route already, but if at some point we add more users (e.g. the police) we may need to do this.