### PR TITLE
[ACR-479] Audit Search Actions

### DIFF
--- a/integration_tests/e2e/locationData/persons.page.cy.ts
+++ b/integration_tests/e2e/locationData/persons.page.cy.ts
@@ -35,6 +35,16 @@ context('Location Data', () => {
       page.dataTable.shouldNotHavePagination()
       page.form.personsSearchField.shouldHaveValue('nomisId')
       page.form.personsSearchField.shouldHaveInputValue('nomisId', 'foo')
+
+      // And the expected audit message was sent
+      cy.expectAuditEvents([
+        {
+          who: 'USER1',
+          details: '{"query":{"name":"","nomisId":"foo","deviceId":"","searchField":"nomisId"}}',
+          what: 'SEARCH_LOCATION_DATA_DEVICE_ACTIVATIONS',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+      ])
     })
 
     it('should display the query results if the query returned results', () => {
@@ -122,6 +132,12 @@ context('Location Data', () => {
 
       // And the expected audit message was sent
       cy.expectAuditEvents([
+        {
+          who: 'USER1',
+          details: '{"query":{"name":"foo","nomisId":"","deviceId":"","searchField":"name"}}',
+          what: 'SEARCH_LOCATION_DATA_DEVICE_ACTIVATIONS',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
         {
           who: 'USER1',
           details: '{"params":{},"query":{"searchField":"name","searchTerm":"foo"}}',
@@ -246,6 +262,16 @@ context('Location Data', () => {
       page.dataTable.pagination.shouldHavePrevButton()
       page.form.personsSearchField.shouldHaveValue('name')
       page.form.personsSearchField.shouldHaveInputValue('name', 'foo')
+
+      // And the expected audit message was sent
+      cy.expectAuditEvents([
+        {
+          who: 'USER1',
+          details: '{"params":{},"query":{"searchField":"name","searchTerm":"foo","page":"2"}}',
+          what: 'PAGE_VIEW_LOCATION_DATA_DEVICE_ACTIVATIONS',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+      ])
     })
 
     it('should display query results when searching by deviceId', () => {

--- a/integration_tests/e2e/locationData/persons.page.error.cy.ts
+++ b/integration_tests/e2e/locationData/persons.page.error.cy.ts
@@ -36,6 +36,12 @@ context('Location Data', () => {
       cy.expectAuditEvents([
         {
           who: 'USER1',
+          details: '{"query":{"name":"foo","nomisId":"","deviceId":"","searchField":"name"}}',
+          what: 'SEARCH_LOCATION_DATA_DEVICE_ACTIVATIONS',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+        {
+          who: 'USER1',
           details: '{"params":{},"query":{"searchField":"name","searchTerm":"foo"}}',
           what: 'PAGE_VIEW_ATTEMPT_LOCATION_DATA_DEVICE_ACTIVATIONS',
           service: 'hmpps-electronic-monitoring-crime-matching-ui',
@@ -55,6 +61,16 @@ context('Location Data', () => {
       // User should be redirected to an error page
       page = Page.verifyOnPage(PersonsPage)
       page.form.personsSearchField.shouldHaveValidationMessage('You must enter a value for Name, NOMIS ID or Device ID')
+
+      // And the expected audit message was sent
+      cy.expectAuditEvents([
+        {
+          who: 'USER1',
+          details: '{"query":{"name":" ","nomisId":"","deviceId":"","searchField":"name"}}',
+          what: 'SEARCH_LOCATION_DATA_DEVICE_ACTIVATIONS',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+      ])
     })
   })
 })

--- a/integration_tests/e2e/locationData/subject-locations.page.cy.ts
+++ b/integration_tests/e2e/locationData/subject-locations.page.cy.ts
@@ -94,6 +94,13 @@ context('Location Data', () => {
         {
           who: 'USER1',
           details:
+            '{"params":{"deviceActivationId":1},"query":{"fromDate":{"date":"01/01/2025","hour":"09","minute":"00"},"toDate":{"date":"02/01/2025","hour":"09","minute":"00"}}}',
+          what: 'SEARCH_LOCATION_DATA_DEVICE_ACTIVATION',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+        {
+          who: 'USER1',
+          details:
             '{"params":{"deviceActivationId":"1"},"query":{"from":"2025-01-01T09:00:00.000Z","to":"2025-01-02T09:00:00.000Z"}}',
           what: 'PAGE_VIEW_LOCATION_DATA_DEVICE_ACTIVATION',
           service: 'hmpps-electronic-monitoring-crime-matching-ui',

--- a/integration_tests/e2e/locationData/subject-locations.page.error.cy.ts
+++ b/integration_tests/e2e/locationData/subject-locations.page.error.cy.ts
@@ -69,6 +69,17 @@ context('Location Data', () => {
       page.dataTable.shouldHaveSelectedRow('1')
       page.locationsForm.fromDateField.shouldHaveValidationMessage('You must enter a valid value for date')
       page.locationsForm.toDateField.shouldHaveValidationMessage('You must enter a valid value for date')
+
+      // And the expected audit message was sent
+      cy.expectAuditEvents([
+        {
+          who: 'USER1',
+          details:
+            '{"params":{"deviceActivationId":1},"query":{"fromDate":{"date":"01/08/2024","hour":" ","minute":" "},"toDate":{"date":"","hour":"","minute":""}}}',
+          what: 'SEARCH_LOCATION_DATA_DEVICE_ACTIVATION',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+      ])
     })
 
     it('should display an error message if date range is from date is before device activation', () => {
@@ -401,6 +412,13 @@ context('Location Data', () => {
 
       // And the expected audit message was sent
       cy.expectAuditEvents([
+        {
+          who: 'USER1',
+          details:
+            '{"params":{"deviceActivationId":1},"query":{"fromDate":{"date":"01/01/2025","hour":"09","minute":"00"},"toDate":{"date":"02/01/2025","hour":"09","minute":"00"}}}',
+          what: 'SEARCH_LOCATION_DATA_DEVICE_ACTIVATION',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
         {
           who: 'USER1',
           details:

--- a/integration_tests/e2e/policeData/dashboard.submission.cy.ts
+++ b/integration_tests/e2e/policeData/dashboard.submission.cy.ts
@@ -129,6 +129,13 @@ context('Police Data Dashboard', () => {
         {
           who: 'USER1',
           details:
+            '{"query":{"batchId":"MPS20251110","fromDate":"1/10/2025","policeForceArea":"METROPOLITAN","toDate":"2/10/2025"}}',
+          what: 'SEARCH_POLICE_DATA_INGESTION_ATTEMPTS',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+        {
+          who: 'USER1',
+          details:
             '{"params":{},"query":{"batchId":"MPS20251110","policeForceArea":"METROPOLITAN","fromDate":"1/10/2025","toDate":"2/10/2025"}}',
           what: 'PAGE_VIEW_POLICE_DATA_INGESTION_ATTEMPTS',
           service: 'hmpps-electronic-monitoring-crime-matching-ui',

--- a/integration_tests/e2e/proximityAlert/searchCrimes.page.cy.ts
+++ b/integration_tests/e2e/proximityAlert/searchCrimes.page.cy.ts
@@ -235,6 +235,16 @@ context('Search Crimes', () => {
       page.dataTable.pagination.shouldHaveCurrentPage('2')
       page.dataTable.pagination.shouldNotHaveNextButton()
       page.dataTable.pagination.shouldHavePrevButton()
+
+      // And the expected audit message was sent
+      cy.expectAuditEvents([
+        {
+          who: 'USER1',
+          details: '{"params":{},"query":{"crimeReference":"abc","page":"2"}}',
+          what: 'PAGE_VIEW_PROXIMITY_ALERT_CRIME_VERSIONS',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+      ])
     })
   })
 })

--- a/integration_tests/e2e/proximityAlert/searchCrimes.submission.cy.ts
+++ b/integration_tests/e2e/proximityAlert/searchCrimes.submission.cy.ts
@@ -28,6 +28,22 @@ context('Search Crimes', () => {
       // Then the page should be reloaded with a new query
       page = Page.verifyOnPage(CrimeSearchPage)
       cy.url().should('contain', '?crimeReference=abc')
+
+      // And the expected audit message was sent
+      cy.expectAuditEvents([
+        {
+          who: 'USER1',
+          details: '{"query":{"crimeReference":"abc"}}',
+          what: 'SEARCH_PROXIMITY_ALERT_CRIME_VERSIONS',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+        {
+          who: 'USER1',
+          details: '{"params":{},"query":{"crimeReference":"abc"}}',
+          what: 'PAGE_VIEW_PROXIMITY_ALERT_CRIME_VERSIONS',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+      ])
     })
   })
 })

--- a/server/controllers/homepage.test.ts
+++ b/server/controllers/homepage.test.ts
@@ -64,7 +64,7 @@ describe('HomepageController', () => {
 
       expect(auditService.logPageView).toHaveBeenCalledWith(Page.HOMEPAGE, {
         who: 'fakeUserName',
-        correlationId: expect.any(String),
+        correlationId: req.id,
       })
       expect(res.render).toHaveBeenCalledWith('pages/index', {
         features: {
@@ -86,7 +86,7 @@ describe('HomepageController', () => {
 
       expect(auditService.logPageView).toHaveBeenCalledWith(Page.HOMEPAGE, {
         who: 'fakeUserName',
-        correlationId: expect.any(String),
+        correlationId: req.id,
       })
       expect(res.render).toHaveBeenCalledWith('pages/index', {
         features: {

--- a/server/controllers/locationData/persons.test.ts
+++ b/server/controllers/locationData/persons.test.ts
@@ -6,13 +6,23 @@ import createMockResponse from '../../testutils/createMockResponse'
 import PersonsService from '../../services/personsService'
 import PersonsController from './persons'
 import CrimeMatchingClient from '../../data/crimeMatchingClient'
+import HmppsAuditClient from '../../data/hmppsAuditClient'
+import AuditService, { Page } from '../../services/auditService'
 
+jest.mock('../../services/auditService')
 jest.mock('../../data/crimeMatchingClient')
 jest.mock('../../../logger')
 
 const mockPerson = createMockPerson()
 
 describe('PersonsController', () => {
+  const hmppsAuditClient = new HmppsAuditClient({
+    queueUrl: '',
+    enabled: true,
+    region: 'eu-west-2',
+    serviceName: '',
+  }) as jest.Mocked<HmppsAuditClient>
+  const auditService = new AuditService(hmppsAuditClient) as jest.Mocked<AuditService>
   let mockRestClient: jest.Mocked<CrimeMatchingClient>
 
   beforeEach(() => {
@@ -35,7 +45,7 @@ describe('PersonsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new PersonsService(mockRestClient)
-      const controller = new PersonsController(service)
+      const controller = new PersonsController(auditService, service)
 
       mockRestClient.getPersonsBySearchTerm.mockResolvedValue({
         data: [mockPerson],
@@ -80,7 +90,7 @@ describe('PersonsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new PersonsService(mockRestClient)
-      const controller = new PersonsController(service)
+      const controller = new PersonsController(auditService, service)
 
       mockRestClient.getPersonsBySearchTerm.mockResolvedValue({
         data: [mockPerson],
@@ -125,7 +135,7 @@ describe('PersonsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new PersonsService(mockRestClient)
-      const controller = new PersonsController(service)
+      const controller = new PersonsController(auditService, service)
 
       mockRestClient.getPersonsBySearchTerm.mockResolvedValue({
         data: [mockPerson],
@@ -165,7 +175,7 @@ describe('PersonsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new PersonsService(mockRestClient)
-      const controller = new PersonsController(service)
+      const controller = new PersonsController(auditService, service)
 
       // When
       await controller.view(req, res, next)
@@ -192,7 +202,7 @@ describe('PersonsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new PersonsService(mockRestClient)
-      const controller = new PersonsController(service)
+      const controller = new PersonsController(auditService, service)
 
       mockRestClient.getPersonsBySearchTerm.mockResolvedValue({
         data: [],
@@ -238,7 +248,7 @@ describe('PersonsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new PersonsService(mockRestClient)
-      const controller = new PersonsController(service)
+      const controller = new PersonsController(auditService, service)
 
       mockRestClient.getPersonsBySearchTerm.mockResolvedValue({
         data: [mockPerson],
@@ -283,7 +293,7 @@ describe('PersonsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new PersonsService(mockRestClient)
-      const controller = new PersonsController(service)
+      const controller = new PersonsController(auditService, service)
 
       // When / Then
       expect(controller.view(req, res, next)).rejects.toBeInstanceOf(ZodError)
@@ -301,7 +311,7 @@ describe('PersonsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new PersonsService(mockRestClient)
-      const controller = new PersonsController(service)
+      const controller = new PersonsController(auditService, service)
 
       // When
       try {
@@ -320,11 +330,24 @@ describe('PersonsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new PersonsService(mockRestClient)
-      const controller = new PersonsController(service)
+      const controller = new PersonsController(auditService, service)
 
       // When
       await controller.search(req, res, next)
 
+      // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.LOCATION_DATA_DEVICE_ACTIVATIONS, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          query: {
+            deviceId: '',
+            name: 'foo',
+            nomisId: '',
+            searchField: 'name',
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith('/location-data/persons?searchField=name&searchTerm=foo')
     })
 
@@ -334,11 +357,24 @@ describe('PersonsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new PersonsService(mockRestClient)
-      const controller = new PersonsController(service)
+      const controller = new PersonsController(auditService, service)
 
       // When
       await controller.search(req, res, next)
 
+      // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.LOCATION_DATA_DEVICE_ACTIVATIONS, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          query: {
+            deviceId: '',
+            name: '',
+            nomisId: 'foo',
+            searchField: 'nomisId',
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith('/location-data/persons?searchField=nomisId&searchTerm=foo')
     })
 
@@ -348,11 +384,24 @@ describe('PersonsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new PersonsService(mockRestClient)
-      const controller = new PersonsController(service)
+      const controller = new PersonsController(auditService, service)
 
       // When
       await controller.search(req, res, next)
 
+      // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.LOCATION_DATA_DEVICE_ACTIVATIONS, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          query: {
+            deviceId: 'foo',
+            name: '',
+            nomisId: '',
+            searchField: 'deviceId',
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith('/location-data/persons?searchField=deviceId&searchTerm=foo')
     })
 
@@ -362,12 +411,24 @@ describe('PersonsController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new PersonsService(mockRestClient)
-      const controller = new PersonsController(service)
+      const controller = new PersonsController(auditService, service)
 
       // When
       await controller.search(req, res, next)
 
       // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.LOCATION_DATA_DEVICE_ACTIVATIONS, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          query: {
+            deviceId: '',
+            name: '',
+            nomisId: '',
+            searchField: 'nomisId',
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith('/location-data/persons')
       expect(req.session.validationErrors).toEqual([
         {

--- a/server/controllers/locationData/persons.ts
+++ b/server/controllers/locationData/persons.ts
@@ -2,9 +2,13 @@ import { RequestHandler } from 'express'
 import { personsFormDataSchema, personsQueryParametersSchema } from '../../schemas/locationData/persons'
 import PersonsService from '../../services/personsService'
 import { convertZodErrorToValidationError } from '../../utils/errors'
+import AuditService, { Page } from '../../services/auditService'
 
 export default class PersonsController {
-  constructor(private readonly service: PersonsService) {}
+  constructor(
+    private readonly auditService: AuditService,
+    private readonly service: PersonsService,
+  ) {}
 
   view: RequestHandler = async (req, res) => {
     const { query } = req
@@ -43,6 +47,19 @@ export default class PersonsController {
     req.session.formData = {
       ...req.body,
     }
+
+    await this.auditService.logSearch(Page.LOCATION_DATA_DEVICE_ACTIVATIONS, {
+      who: res.locals.user.username,
+      correlationId: req.id,
+      details: {
+        query: {
+          name: req.body.name,
+          nomisId: req.body.nomisId,
+          deviceId: req.body.deviceId,
+          searchField: req.body.searchField,
+        },
+      },
+    })
 
     if (formData.success) {
       const params = `searchField=${formData.data.searchField}&searchTerm=${formData.data.searchTerm}`

--- a/server/controllers/locationData/subject.test.ts
+++ b/server/controllers/locationData/subject.test.ts
@@ -88,6 +88,19 @@ describe('SubjectController', () => {
       await controller.search(req, res, next)
 
       // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.LOCATION_DATA_DEVICE_ACTIVATION, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          params: {
+            deviceActivationId: 1,
+          },
+          query: {
+            fromDate: fromDateInput,
+            toDate: toDateInput,
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith(
         '/location-data/device-activations/1?from=2025-02-01T01:01:01.000Z&to=2025-02-02T01:01:01.000Z',
       )
@@ -125,6 +138,19 @@ describe('SubjectController', () => {
       await controller.search(req, res, next)
 
       // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.LOCATION_DATA_DEVICE_ACTIVATION, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          params: {
+            deviceActivationId: undefined,
+          },
+          query: {
+            fromDate: emptyDateInput,
+            toDate: emptyDateInput,
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith('/location-data/persons?name=foo&nomisId=')
       expect(req.session.validationErrors).toEqual([
         {
@@ -177,6 +203,19 @@ describe('SubjectController', () => {
       await controller.search(req, res, next)
 
       // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.LOCATION_DATA_DEVICE_ACTIVATION, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          params: {
+            deviceActivationId: undefined,
+          },
+          query: {
+            fromDate: fromDateInput,
+            toDate: toDateInput,
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith('/location-data/device-activations/1')
       expect(req.session.validationErrors).toEqual([
         {
@@ -224,6 +263,19 @@ describe('SubjectController', () => {
       await controller.search(req, res, next)
 
       // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.LOCATION_DATA_DEVICE_ACTIVATION, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          params: {
+            deviceActivationId: undefined,
+          },
+          query: {
+            fromDate: fromDateInput,
+            toDate: toDateInput,
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith('/location-data/device-activations/1')
       expect(req.session.validationErrors).toEqual([
         {
@@ -282,6 +334,19 @@ describe('SubjectController', () => {
       await controller.search(req, res, next)
 
       // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.LOCATION_DATA_DEVICE_ACTIVATION, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          params: {
+            deviceActivationId: 1,
+          },
+          query: {
+            fromDate: fromDateInput,
+            toDate: toDateInput,
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith('/location-data/device-activations/1')
       expect(req.session.validationErrors).toEqual([
         {
@@ -340,6 +405,19 @@ describe('SubjectController', () => {
       await controller.search(req, res, next)
 
       // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.LOCATION_DATA_DEVICE_ACTIVATION, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          params: {
+            deviceActivationId: 1,
+          },
+          query: {
+            fromDate: fromDateInput,
+            toDate: toDateInput,
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith('/location-data/device-activations/1')
       expect(req.session.validationErrors).toEqual([
         {

--- a/server/controllers/locationData/subject.ts
+++ b/server/controllers/locationData/subject.ts
@@ -48,6 +48,20 @@ export default class SubjectController {
     const deviceActivation = req.deviceActivation!
     const formData = searchLocationsFormDataSchema.safeParse(req.body)
 
+    await this.auditService.logSearch(Page.LOCATION_DATA_DEVICE_ACTIVATION, {
+      who: res.locals.user.username,
+      correlationId: req.id,
+      details: {
+        params: {
+          deviceActivationId: deviceActivation?.deviceActivationId,
+        },
+        query: {
+          fromDate: req.body.fromDate,
+          toDate: req.body.toDate,
+        },
+      },
+    })
+
     if (formData.success) {
       const fromDate = parseDateTimeFromISOString(formData.data.fromDate)
       const toDate = parseDateTimeFromISOString(formData.data.toDate)

--- a/server/controllers/policeData/dashboard.test.ts
+++ b/server/controllers/policeData/dashboard.test.ts
@@ -116,6 +116,18 @@ describe('PoliceDataDashboardController', () => {
       await controller.search(req, res, next)
 
       // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.POLICE_DATA_INGESTION_ATTEMPTS, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          query: {
+            batchId: '',
+            fromDate: '',
+            policeForceArea: '',
+            toDate: '',
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith(303, '/police-data/dashboard')
       expect(next).not.toHaveBeenCalled()
     })
@@ -133,6 +145,18 @@ describe('PoliceDataDashboardController', () => {
       await controller.search(req, res, next)
 
       // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.POLICE_DATA_INGESTION_ATTEMPTS, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          query: {
+            batchId: 'A&B=C',
+            fromDate: '',
+            policeForceArea: '',
+            toDate: '',
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith(303, '/police-data/dashboard?batchId=A%26B%3DC')
       expect(next).not.toHaveBeenCalled()
     })

--- a/server/controllers/policeData/dashboard.ts
+++ b/server/controllers/policeData/dashboard.ts
@@ -33,6 +33,19 @@ export default class PoliceDataDashboardController {
     const { batchId, policeForceArea, fromDate, toDate } = policeDataDashboardQuerySchema.parse(req.body)
     const query = this.getQueryString(batchId, policeForceArea, fromDate, toDate)
 
+    await this.auditService.logSearch(Page.POLICE_DATA_INGESTION_ATTEMPTS, {
+      who: res.locals.user.username,
+      correlationId: req.id,
+      details: {
+        query: {
+          batchId,
+          fromDate,
+          policeForceArea,
+          toDate,
+        },
+      },
+    })
+
     return res.redirect(303, `${URLS.POLICE_DATA.INGESTION_ATTEMPTS.VIEW}${query ? `?${query}` : ''}`)
   }
 

--- a/server/controllers/proximityAlert/crimeSearch.test.ts
+++ b/server/controllers/proximityAlert/crimeSearch.test.ts
@@ -4,7 +4,10 @@ import createMockRequest from '../../testutils/createMockRequest'
 import createMockResponse from '../../testutils/createMockResponse'
 import CrimeSearchController from './crimeSearch'
 import logger from '../../../logger'
+import HmppsAuditClient from '../../data/hmppsAuditClient'
+import AuditService, { Page } from '../../services/auditService'
 
+jest.mock('../../services/auditService')
 jest.mock('../../data/crimeMatchingClient')
 jest.mock('../../../logger')
 
@@ -16,6 +19,13 @@ const expectedAuthOptions = {
 }
 
 describe('CrimeSearchController', () => {
+  const hmppsAuditClient = new HmppsAuditClient({
+    queueUrl: '',
+    enabled: true,
+    region: 'eu-west-2',
+    serviceName: '',
+  }) as jest.Mocked<HmppsAuditClient>
+  const auditService = new AuditService(hmppsAuditClient) as jest.Mocked<AuditService>
   let mockRestClient: jest.Mocked<CrimeMatchingClient>
 
   beforeEach(() => {
@@ -37,7 +47,7 @@ describe('CrimeSearchController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new CrimeService(mockRestClient)
-      const controller = new CrimeSearchController(service)
+      const controller = new CrimeSearchController(auditService, service)
 
       // When
       await controller.search(req, res, next)
@@ -53,12 +63,21 @@ describe('CrimeSearchController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new CrimeService(mockRestClient)
-      const controller = new CrimeSearchController(service)
+      const controller = new CrimeSearchController(auditService, service)
 
       // When
       await controller.search(req, res, next)
 
       // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.PROXIMITY_ALERT_CRIME_VERSIONS, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          query: {
+            crimeReference: null,
+          },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith(303, '/proximity-alert')
       expect(next).not.toHaveBeenCalled()
     })
@@ -69,12 +88,19 @@ describe('CrimeSearchController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new CrimeService(mockRestClient)
-      const controller = new CrimeSearchController(service)
+      const controller = new CrimeSearchController(auditService, service)
 
       // When
       await controller.search(req, res, next)
 
       // Then
+      expect(auditService.logSearch).toHaveBeenCalledWith(Page.PROXIMITY_ALERT_CRIME_VERSIONS, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          query: { crimeReference: 'A&B=C' },
+        },
+      })
       expect(res.redirect).toHaveBeenCalledWith(303, '/proximity-alert?crimeReference=A%26B%3DC')
       expect(next).not.toHaveBeenCalled()
     })
@@ -89,7 +115,7 @@ describe('CrimeSearchController', () => {
         const res = createMockResponse()
         const next = jest.fn()
         const service = new CrimeService(mockRestClient)
-        const controller = new CrimeSearchController(service)
+        const controller = new CrimeSearchController(auditService, service)
 
         // When
         await controller.view(req, res, next)
@@ -113,7 +139,7 @@ describe('CrimeSearchController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new CrimeService(mockRestClient)
-      const controller = new CrimeSearchController(service)
+      const controller = new CrimeSearchController(auditService, service)
 
       // When
       await controller.view(req, res, next)
@@ -137,7 +163,7 @@ describe('CrimeSearchController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new CrimeService(mockRestClient)
-      const controller = new CrimeSearchController(service)
+      const controller = new CrimeSearchController(auditService, service)
 
       mockRestClient.getCrimeVersions.mockResolvedValue({
         data: [
@@ -223,7 +249,7 @@ describe('CrimeSearchController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new CrimeService(mockRestClient)
-      const controller = new CrimeSearchController(service)
+      const controller = new CrimeSearchController(auditService, service)
 
       mockRestClient.getCrimeVersions.mockResolvedValue({
         data: [],

--- a/server/controllers/proximityAlert/crimeSearch.ts
+++ b/server/controllers/proximityAlert/crimeSearch.ts
@@ -3,9 +3,13 @@ import { crimeSearchQuerySchema } from '../../schemas/proximityAlert/crimeSearch
 import CrimeService from '../../services/crimeService'
 import presentCrimeVersionSummaries from '../../presenters/crimeVersionSummary'
 import URLS from '../../constants/urls'
+import AuditService, { Page } from '../../services/auditService'
 
 export default class CrimeSearchController {
-  constructor(private readonly crimeService: CrimeService) {}
+  constructor(
+    private readonly auditService: AuditService,
+    private readonly crimeService: CrimeService,
+  ) {}
 
   private getQueryString = (crimeReference: string | null): string => {
     const searchParams = new URLSearchParams({
@@ -18,6 +22,16 @@ export default class CrimeSearchController {
   search: RequestHandler = async (req, res) => {
     const { crimeReference } = crimeSearchQuerySchema.parse(req.body)
     const query = this.getQueryString(crimeReference)
+
+    await this.auditService.logSearch(Page.PROXIMITY_ALERT_CRIME_VERSIONS, {
+      who: res.locals.user.username,
+      correlationId: req.id,
+      details: {
+        query: {
+          crimeReference,
+        },
+      },
+    })
 
     return res.redirect(303, `${URLS.PROXIMITY_ALERT.CRIME_VERSIONS.VIEW}${query ? `?${query}` : ''}`)
   }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -20,7 +20,7 @@ export default function routes(services: Services): Router {
   const homepageController = new HomepageController(auditService, featuresService)
   const helpController = new HelpController()
   const legalController = new LegalController()
-  const personsController = new PersonsController(personsService)
+  const personsController = new PersonsController(auditService, personsService)
 
   router.use(populateSessionData)
 

--- a/server/routes/proximity-alert.ts
+++ b/server/routes/proximity-alert.ts
@@ -16,7 +16,7 @@ const proximityAlertRoutes = ({
   playwrightBrowserService,
 }: Services): Router => {
   const router = Router()
-  const crimeSearchController = new CrimeSearchController(crimeService)
+  const crimeSearchController = new CrimeSearchController(auditService, crimeService)
   const mapImageRendererService = new MapImageRendererService()
   const proximityAlertReportDocxService = new ProximityAlertReportDocxService()
   const proximityAlertReportExportService = new ProximityAlertReportExportService(

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -93,4 +93,21 @@ describe('Audit service', () => {
       })
     })
   })
+
+  describe('logSearch', () => {
+    it('sends a search event audit message using audit client', async () => {
+      await auditService.logSearch(Page.POLICE_DATA_INGESTION_ATTEMPTS, {
+        who: 'user1',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
+        what: 'SEARCH_POLICE_DATA_INGESTION_ATTEMPTS',
+        who: 'user1',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+    })
+  })
 })

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -49,4 +49,12 @@ export default class AuditService {
     }
     await this.hmppsAuditClient.sendMessage(event)
   }
+
+  async logSearch(page: Page, eventDetails: PageViewEventDetails) {
+    const event: AuditEvent = {
+      ...eventDetails,
+      what: `SEARCH_${page}`,
+    }
+    await this.hmppsAuditClient.sendMessage(event)
+  }
 }


### PR DESCRIPTION
Adding audit logging for search actions, search events will be sent whenever a search is triggered, the existing page view events will verify a successful or unsuccessful search.