### PR TITLE
ACR-479 - Hub Managers Auditing

### DIFF
--- a/integration_tests/e2e/hubManager/create.page.cy.ts
+++ b/integration_tests/e2e/hubManager/create.page.cy.ts
@@ -81,6 +81,20 @@ context('Create Hub Manager', () => {
 
       // Then the page should redirect to the list
       Page.verifyOnPage(ListHubManagersPage)
+
+      // And the expected audit messages are sent
+      cy.expectAuditEvents([
+        {
+          who: 'USER1',
+          what: 'CREATE_ATTEMPT_HUB_MANAGER',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+        {
+          who: 'USER1',
+          what: 'CREATE_SUCCESS_HUB_MANAGER',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+      ])
     })
   })
 })

--- a/integration_tests/e2e/hubManager/list.page.cy.ts
+++ b/integration_tests/e2e/hubManager/list.page.cy.ts
@@ -97,6 +97,22 @@ context('Create Hub Manager', () => {
 
       // Then the user should be shown an updated list of hub managers
       Page.verifyOnPage(ListHubManagersPage)
+
+      // And the expected audit messages are sent
+      cy.expectAuditEvents([
+        {
+          who: 'USER1',
+          details: '{"params":{"id":"205250b7-c150-410e-8dca-70c170dcec85"}}',
+          what: 'DELETE_ATTEMPT_HUB_MANAGER',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+        {
+          who: 'USER1',
+          details: '{"params":{"id":"205250b7-c150-410e-8dca-70c170dcec85"}}',
+          what: 'DELETE_SUCCESS_HUB_MANAGER',
+          service: 'hmpps-electronic-monitoring-crime-matching-ui',
+        },
+      ])
     })
   })
 })

--- a/server/controllers/hubManagers/create.test.ts
+++ b/server/controllers/hubManagers/create.test.ts
@@ -1,6 +1,8 @@
 import logger from '../../../logger'
 import URLS from '../../constants/urls'
 import CrimeMatchingClient from '../../data/crimeMatchingClient'
+import HmppsAuditClient from '../../data/hmppsAuditClient'
+import AuditService, { Page } from '../../services/auditService'
 import HubManagersService from '../../services/hubManagerService'
 import createMockFile from '../../testutils/createMockFile'
 import createMockRequest from '../../testutils/createMockRequest'
@@ -8,10 +10,18 @@ import createMockResponse from '../../testutils/createMockResponse'
 import expectedAuthOptions from '../../testutils/expectedAuthOptions'
 import CreateHubManagersController from './create'
 
+jest.mock('../../services/auditService')
 jest.mock('../../data/crimeMatchingClient')
 jest.mock('../../../logger')
 
 describe('CreateHubManagerController', () => {
+  const hmppsAuditClient = new HmppsAuditClient({
+    queueUrl: '',
+    enabled: true,
+    region: 'eu-west-2',
+    serviceName: '',
+  }) as jest.Mocked<HmppsAuditClient>
+  const auditService = new AuditService(hmppsAuditClient) as jest.Mocked<AuditService>
   let mockRestClient: jest.Mocked<CrimeMatchingClient>
 
   beforeEach(() => {
@@ -29,7 +39,7 @@ describe('CreateHubManagerController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new HubManagersService(mockRestClient)
-      const controller = new CreateHubManagersController(service)
+      const controller = new CreateHubManagersController(auditService, service)
 
       // When
       await controller.view(req, res, next)
@@ -48,7 +58,7 @@ describe('CreateHubManagerController', () => {
         const res = createMockResponse()
         const next = jest.fn()
         const service = new HubManagersService(mockRestClient)
-        const controller = new CreateHubManagersController(service)
+        const controller = new CreateHubManagersController(auditService, service)
 
         // When
         await controller.submit(req, res, next)
@@ -62,6 +72,10 @@ describe('CreateHubManagerController', () => {
             file: 'Upload a file',
             name: 'Enter a name',
           },
+        })
+        expect(auditService.logApiModificationCall).toHaveBeenCalledWith('ATTEMPT', 'CREATE', Page.HUB_MANAGER, {
+          who: 'fakeUserName',
+          correlationId: req.id,
         })
       },
     )
@@ -77,7 +91,7 @@ describe('CreateHubManagerController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new HubManagersService(mockRestClient)
-      const controller = new CreateHubManagersController(service)
+      const controller = new CreateHubManagersController(auditService, service)
 
       mockRestClient.createHubManager.mockResolvedValue({
         data: {
@@ -108,6 +122,14 @@ describe('CreateHubManagerController', () => {
         }),
       )
       expect(res.redirect).toHaveBeenCalledWith(303, URLS.HUB_MANAGERS.VIEW)
+      expect(auditService.logApiModificationCall).toHaveBeenCalledWith('ATTEMPT', 'CREATE', Page.HUB_MANAGER, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+      })
+      expect(auditService.logApiModificationCall).toHaveBeenCalledWith('SUCCESS', 'CREATE', Page.HUB_MANAGER, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+      })
     })
   })
 })

--- a/server/controllers/hubManagers/create.ts
+++ b/server/controllers/hubManagers/create.ts
@@ -1,9 +1,13 @@
 import { RequestHandler } from 'express'
 import HubManagersService from '../../services/hubManagerService'
 import URLS from '../../constants/urls'
+import AuditService, { Page } from '../../services/auditService'
 
 export default class CreateHubManagersController {
-  constructor(private readonly hubManagersService: HubManagersService) {}
+  constructor(
+    private readonly auditService: AuditService,
+    private readonly hubManagersService: HubManagersService,
+  ) {}
 
   view: RequestHandler = async (req, res) => {
     res.render('pages/hubManagers/create')
@@ -15,7 +19,16 @@ export default class CreateHubManagersController {
     const { file } = req
     const result = await this.hubManagersService.createHubManager(username, name, file)
 
+    await this.auditService.logApiModificationCall('ATTEMPT', 'CREATE', Page.HUB_MANAGER, {
+      who: res.locals.user.username,
+      correlationId: req.id,
+    })
+
     if (result.ok) {
+      await this.auditService.logApiModificationCall('SUCCESS', 'CREATE', Page.HUB_MANAGER, {
+        who: res.locals.user.username,
+        correlationId: req.id,
+      })
       res.redirect(303, URLS.HUB_MANAGERS.VIEW)
     } else {
       res.render('pages/hubManagers/create', {

--- a/server/controllers/hubManagers/list.test.ts
+++ b/server/controllers/hubManagers/list.test.ts
@@ -1,16 +1,26 @@
 import logger from '../../../logger'
 import URLS from '../../constants/urls'
 import CrimeMatchingClient from '../../data/crimeMatchingClient'
+import HmppsAuditClient from '../../data/hmppsAuditClient'
+import AuditService, { Page } from '../../services/auditService'
 import HubManagersService from '../../services/hubManagerService'
 import createMockRequest from '../../testutils/createMockRequest'
 import createMockResponse from '../../testutils/createMockResponse'
 import expectedAuthOptions from '../../testutils/expectedAuthOptions'
 import ListHubManagersController from './list'
 
+jest.mock('../../services/auditService')
 jest.mock('../../data/crimeMatchingClient')
 jest.mock('../../../logger')
 
 describe('ListHubManagersController', () => {
+  const hmppsAuditClient = new HmppsAuditClient({
+    queueUrl: '',
+    enabled: true,
+    region: 'eu-west-2',
+    serviceName: '',
+  }) as jest.Mocked<HmppsAuditClient>
+  const auditService = new AuditService(hmppsAuditClient) as jest.Mocked<AuditService>
   let mockRestClient: jest.Mocked<CrimeMatchingClient>
 
   beforeEach(() => {
@@ -28,7 +38,7 @@ describe('ListHubManagersController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new HubManagersService(mockRestClient)
-      const controller = new ListHubManagersController(service)
+      const controller = new ListHubManagersController(auditService, service)
 
       mockRestClient.getHubManagers.mockResolvedValue({
         data: [
@@ -66,7 +76,7 @@ describe('ListHubManagersController', () => {
       const res = createMockResponse()
       const next = jest.fn()
       const service = new HubManagersService(mockRestClient)
-      const controller = new ListHubManagersController(service)
+      const controller = new ListHubManagersController(auditService, service)
 
       // When
       await controller.delete(req, res, next)
@@ -77,6 +87,24 @@ describe('ListHubManagersController', () => {
         'b90f4016-6d0d-4a70-a1ac-a48e43dc48eb',
       )
       expect(res.redirect).toHaveBeenCalledWith(303, URLS.HUB_MANAGERS.VIEW)
+      expect(auditService.logApiModificationCall).toHaveBeenCalledWith('ATTEMPT', 'DELETE', Page.HUB_MANAGER, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          params: {
+            id: 'b90f4016-6d0d-4a70-a1ac-a48e43dc48eb',
+          },
+        },
+      })
+      expect(auditService.logApiModificationCall).toHaveBeenCalledWith('SUCCESS', 'DELETE', Page.HUB_MANAGER, {
+        who: 'fakeUserName',
+        correlationId: req.id,
+        details: {
+          params: {
+            id: 'b90f4016-6d0d-4a70-a1ac-a48e43dc48eb',
+          },
+        },
+      })
     })
   })
 })

--- a/server/controllers/hubManagers/list.ts
+++ b/server/controllers/hubManagers/list.ts
@@ -1,15 +1,39 @@
 import { RequestHandler } from 'express'
 import HubManagersService from '../../services/hubManagerService'
 import URLS from '../../constants/urls'
+import AuditService, { Page } from '../../services/auditService'
 
 export default class ListHubManagersController {
-  constructor(private readonly hubManagersService: HubManagersService) {}
+  constructor(
+    private readonly auditService: AuditService,
+    private readonly hubManagersService: HubManagersService,
+  ) {}
 
   delete: RequestHandler = async (req, res) => {
     const { username } = res.locals.user
     const { id } = req.params
 
+    await this.auditService.logApiModificationCall('ATTEMPT', 'DELETE', Page.HUB_MANAGER, {
+      who: res.locals.user.username,
+      correlationId: req.id,
+      details: {
+        params: {
+          id,
+        },
+      },
+    })
+
     await this.hubManagersService.deleteHubManager(username, id)
+
+    await this.auditService.logApiModificationCall('SUCCESS', 'DELETE', Page.HUB_MANAGER, {
+      who: res.locals.user.username,
+      correlationId: req.id,
+      details: {
+        params: {
+          id,
+        },
+      },
+    })
 
     res.redirect(303, URLS.HUB_MANAGERS.VIEW)
   }

--- a/server/middleware/auditMiddleware.ts
+++ b/server/middleware/auditMiddleware.ts
@@ -34,20 +34,12 @@ export default function auditMiddleware({ auditService }: Services) {
         },
       }
 
-      let succeeded = false
+      auditService.logPageViewAttempt(page, auditDetails)
 
       // Log a view if successful
       res.prependOnceListener('finish', () => {
         if (res.statusCode === 200) {
-          succeeded = true
           auditService.logPageView(page, auditDetails)
-        }
-      })
-
-      // Only logs attempts on failure
-      res.on('close', () => {
-        if (!succeeded) {
-          auditService.logPageViewAttempt(page, auditDetails)
         }
       })
 

--- a/server/routes/hubManagers.test.ts
+++ b/server/routes/hubManagers.test.ts
@@ -83,7 +83,14 @@ describe('/hub-managers', () => {
         .expect(res => {
           expect(res.status).toEqual(200)
           expect(res.text).toContain('Hub managers')
-          expect(auditService.logPageViewAttempt).not.toHaveBeenCalled()
+          expect(auditService.logPageViewAttempt).toHaveBeenCalledWith(Page.HUB_MANAGERS, {
+            who: 'user1',
+            correlationId: expect.any(String),
+            details: {
+              params: {},
+              query: {},
+            },
+          })
           expect(auditService.logPageView).toHaveBeenCalledWith(Page.HUB_MANAGERS, {
             who: 'user1',
             correlationId: expect.any(String),
@@ -145,6 +152,7 @@ describe('/hub-managers', () => {
       const hubManagersService = new HubManagersService(restClient)
       const app = appWithAllRoutes({
         services: {
+          auditService,
           hubManagersService,
         },
         userSupplier: () => hubManager,
@@ -184,6 +192,7 @@ describe('/hub-managers', () => {
       const hubManagersService = new HubManagersService(restClient)
       const app = appWithAllRoutes({
         services: {
+          auditService,
           hubManagersService,
         },
         userSupplier: () => hubManager,

--- a/server/routes/hubManagers.ts
+++ b/server/routes/hubManagers.ts
@@ -7,10 +7,10 @@ import URLS from '../constants/urls'
 import { ROLES } from '../constants/roles'
 import hasRole from '../middleware/hasRole'
 
-const hubManagersRoutes = ({ hubManagersService }: Services): Router => {
+const hubManagersRoutes = ({ auditService, hubManagersService }: Services): Router => {
   const router = Router()
-  const listController = new ListHubManagersController(hubManagersService)
-  const createController = new CreateHubManagersController(hubManagersService)
+  const listController = new ListHubManagersController(auditService, hubManagersService)
+  const createController = new CreateHubManagersController(auditService, hubManagersService)
 
   router.use(URLS.HUB_MANAGERS.VIEW, hasRole(ROLES.CRIME_MATCHING_HUB_MANAGER))
 

--- a/server/routes/location-data.test.ts
+++ b/server/routes/location-data.test.ts
@@ -127,7 +127,16 @@ describe('/location-data', () => {
         .expect(res => {
           expect(res.status).toEqual(200)
           expect(res.text).toContain('<title>HMPPS Electronic Monitoring Crime Matching - Home</title>')
-          expect(auditService.logPageViewAttempt).not.toHaveBeenCalled()
+          expect(auditService.logPageViewAttempt).toHaveBeenCalledWith(Page.LOCATION_DATA_DEVICE_ACTIVATION, {
+            who: 'user1',
+            correlationId: expect.any(String),
+            details: {
+              params: {
+                deviceActivationId: '123456789',
+              },
+              query: {},
+            },
+          })
           expect(auditService.logPageView).toHaveBeenCalledWith(Page.LOCATION_DATA_DEVICE_ACTIVATION, {
             who: 'user1',
             correlationId: expect.any(String),

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -39,6 +39,23 @@ describe('Audit service', () => {
     })
   })
 
+  describe('logApiModificationCall', () => {
+    it('sends an API modification event audit message using audit client', async () => {
+      await auditService.logApiModificationCall('SUCCESS', 'CREATE', Page.HUB_MANAGER, {
+        who: 'user1',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
+        what: 'CREATE_SUCCESS_HUB_MANAGER',
+        who: 'user1',
+        correlationId: 'request123',
+        details: { extraDetails: 'example' },
+      })
+    })
+  })
+
   describe('logExport', () => {
     it('sends an export event audit message using audit client', async () => {
       await auditService.logExport(Page.POLICE_DATA_INGESTION_ATTEMPT, {

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -2,6 +2,7 @@ import HmppsAuditClient, { AuditEvent } from '../data/hmppsAuditClient'
 
 export enum Page {
   HOMEPAGE = 'HOMEPAGE',
+  HUB_MANAGER = 'HUB_MANAGER',
   HUB_MANAGERS = 'HUB_MANAGERS',
   LOCATION_DATA_DEVICE_ACTIVATION = 'LOCATION_DATA_DEVICE_ACTIVATION',
   LOCATION_DATA_DEVICE_ACTIVATIONS = 'LOCATION_DATA_DEVICE_ACTIVATIONS',
@@ -23,6 +24,19 @@ export default class AuditService {
   constructor(private readonly hmppsAuditClient: HmppsAuditClient) {}
 
   async logAuditEvent(event: AuditEvent) {
+    await this.hmppsAuditClient.sendMessage(event)
+  }
+
+  async logApiModificationCall(
+    auditType: 'ATTEMPT' | 'SUCCESS',
+    action: 'CREATE' | 'DELETE',
+    page: Page,
+    eventDetails: PageViewEventDetails,
+  ) {
+    const event: AuditEvent = {
+      ...eventDetails,
+      what: `${action}_${auditType}_${page}`,
+    }
     await this.hmppsAuditClient.sendMessage(event)
   }
 


### PR DESCRIPTION
Adding hub managers auditing for creating and deleting functionality and updating view attempt events to be emitted regardless of successful view outcome.