### PR TITLE
Group positions by Sequence letter

### DIFF
--- a/assets/js/views/proximity-alert/layers/deviceWearer.ts
+++ b/assets/js/views/proximity-alert/layers/deviceWearer.ts
@@ -7,26 +7,57 @@ import {
 import LayerGroup from 'ol/layer/Group'
 import { Position } from '@ministryofjustice/hmpps-electronic-monitoring-components/map'
 
+type PositionWithSequenceLabel = Position & {
+  sequenceLabel?: string
+}
+
+// Extracts the sequence key from a sequence label, e.g. "A1" -> "A", "B2" -> "B", "unknown" if no match.
+const sequenceKeyFromLabel = (sequenceLabel?: string): string => sequenceLabel?.match(/^[A-Za-z]+/)?.[0] ?? 'unknown'
+
+// Tracks should be drawn independently for each matching sequence, e.g. A1/A2/A3 and B1/B2/B3.
+const groupPositionsBySequence = (
+  positions: Array<PositionWithSequenceLabel>,
+): Array<Array<PositionWithSequenceLabel>> => {
+  const groups = new Map<string, Array<PositionWithSequenceLabel>>()
+
+  positions.forEach(position => {
+    const sequenceKey = sequenceKeyFromLabel(position.sequenceLabel)
+    const existingGroup = groups.get(sequenceKey)
+
+    if (existingGroup) {
+      // Add to the existing group for this sequence key
+      existingGroup.push(position)
+    } else {
+      // Create a new group for this sequence key
+      groups.set(sequenceKey, [position])
+    }
+  })
+
+  return Array.from(groups.values())
+}
+
 class DeviceWearerLayer extends LayerGroup {
-  constructor(deviceId: number, crime: Position, positions: Array<Position>, colour: string) {
+  constructor(deviceId: number, crime: Position, positions: Array<PositionWithSequenceLabel>, colour: string) {
     super({
       properties: {
         title: `device-wearer-${deviceId}`,
       },
       layers: [
         // Tracks
-        ...new TracksLayer({
-          title: `device-wearer-tracks-${deviceId}`,
-          positions,
-          entryExit: {
-            enabled: true,
-            extensionDistanceMeters: 50,
-            centre: [crime.longitude, crime.latitude],
-            radiusMeters: crime.precision,
-          },
-          zIndex: 2,
-          visible: false,
-        }).getLayers(),
+        ...groupPositionsBySequence(positions).flatMap(sequencePositions =>
+          new TracksLayer({
+            title: `device-wearer-tracks-${deviceId}`,
+            positions: sequencePositions,
+            entryExit: {
+              enabled: true,
+              extensionDistanceMeters: 50,
+              centre: [crime.longitude, crime.latitude],
+              radiusMeters: crime.precision,
+            },
+            zIndex: 2,
+            visible: false,
+          }).getLayers(),
+        ),
 
         // Labels
         ...new TextLayer({

--- a/assets/js/views/proximity-alert/layers/deviceWearer.ts
+++ b/assets/js/views/proximity-alert/layers/deviceWearer.ts
@@ -15,9 +15,7 @@ type PositionWithSequenceLabel = Position & {
 const sequenceKeyFromLabel = (sequenceLabel?: string): string => sequenceLabel?.match(/^[A-Za-z]+/)?.[0] ?? 'unknown'
 
 // Tracks should be drawn independently for each matching sequence, e.g. A1/A2/A3 and B1/B2/B3.
-const groupPositionsBySequence = (
-  positions: Array<PositionWithSequenceLabel>,
-): Array<Array<PositionWithSequenceLabel>> => {
+const groupPositionsBySequence = (positions: Array<PositionWithSequenceLabel>) => {
   const groups = new Map<string, Array<PositionWithSequenceLabel>>()
 
   positions.forEach(position => {
@@ -33,7 +31,7 @@ const groupPositionsBySequence = (
     }
   })
 
-  return Array.from(groups.values())
+  return Array.from(groups.entries())
 }
 
 class DeviceWearerLayer extends LayerGroup {
@@ -44,9 +42,9 @@ class DeviceWearerLayer extends LayerGroup {
       },
       layers: [
         // Tracks
-        ...groupPositionsBySequence(positions).flatMap(sequencePositions =>
+        ...groupPositionsBySequence(positions).flatMap(([sequenceKey, sequencePositions]) =>
           new TracksLayer({
-            title: `device-wearer-tracks-${deviceId}`,
+            title: `device-wearer-tracks-${deviceId}-${sequenceKey}`,
             positions: sequencePositions,
             entryExit: {
               enabled: true,

--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
@@ -6,7 +6,14 @@ import VectorLayer from 'ol/layer/Vector'
 import { Style } from 'ol/style'
 import Page from '../../pages/page'
 import CrimeVersionPage from '../../pages/proximityAlert/crimeVersion'
-import { crimeLocation, crimeVersionId, crimeVersionWithManyMatches, deviceLocation, hubManager } from './fixtures'
+import {
+  crimeLocation,
+  crimeVersionId,
+  crimeVersionWithManyMatches,
+  crimeVersionWithMultipleSequences,
+  deviceLocation,
+  hubManager,
+} from './fixtures'
 import { hubCaseworker } from '../../fixtures/auth'
 
 const getTitle = (layer: BaseLayer): string => {
@@ -79,14 +86,39 @@ context('Crime Version', () => {
       page.map.mapInstance.then(map => {
         // Then the numbers, circles, positions layers should be shown
         expect(getLayers(map)).to.deep.eq([
-          { title: 'device-wearer-tracks-1', visible: false },
+          { title: 'device-wearer-tracks-1-A', visible: false },
           { title: 'device-wearer-labels-1', visible: true },
           { title: 'device-wearer-circles-1', visible: true },
           { title: 'device-wearer-positions-1', visible: true },
-          { title: 'device-wearer-tracks-2', visible: false },
+          { title: 'device-wearer-tracks-2-A', visible: false },
           { title: 'device-wearer-labels-2', visible: true },
           { title: 'device-wearer-circles-2', visible: true },
           { title: 'device-wearer-positions-2', visible: true },
+        ])
+      })
+    })
+
+    it('should display matching sequences as independent track layers', () => {
+      // Given an API response containing a crime version with multiple sequences
+      cy.stubGetCrimeVersion({
+        status: 200,
+        crimeVersionId,
+        response: {
+          data: crimeVersionWithMultipleSequences,
+        },
+      })
+
+      // When the user loads the page
+      cy.visit(`/proximity-alert/${crimeVersionId}`)
+
+      const page = Page.verifyOnPage(CrimeVersionPage)
+
+      // And the map is ready
+      page.map.mapInstance.then(map => {
+        // Then each matching sequence should be represented by its own tracks layer
+        expect(getLayers(map, /^device-wearer-tracks-1-[A-Z]+$/)).to.deep.eq([
+          { title: 'device-wearer-tracks-1-A', visible: false },
+          { title: 'device-wearer-tracks-1-B', visible: false },
         ])
       })
     })
@@ -122,11 +154,11 @@ context('Crime Version', () => {
         // Then the circles layers should be hidden
         cy.wait(100).then(() => {
           expect(getLayers(map)).to.deep.eq([
-            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-tracks-1-A', visible: false },
             { title: 'device-wearer-labels-1', visible: true },
             { title: 'device-wearer-circles-1', visible: false },
             { title: 'device-wearer-positions-1', visible: true },
-            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-tracks-2-A', visible: false },
             { title: 'device-wearer-labels-2', visible: true },
             { title: 'device-wearer-circles-2', visible: false },
             { title: 'device-wearer-positions-2', visible: true },
@@ -150,11 +182,11 @@ context('Crime Version', () => {
         // Then the numbering layers should be hidden
         cy.wait(100).then(() => {
           expect(getLayers(map)).to.deep.eq([
-            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-tracks-1-A', visible: false },
             { title: 'device-wearer-labels-1', visible: false },
             { title: 'device-wearer-circles-1', visible: true },
             { title: 'device-wearer-positions-1', visible: true },
-            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-tracks-2-A', visible: false },
             { title: 'device-wearer-labels-2', visible: false },
             { title: 'device-wearer-circles-2', visible: true },
             { title: 'device-wearer-positions-2', visible: true },
@@ -177,11 +209,11 @@ context('Crime Version', () => {
         // Then the device wearer 1 layers should be hidden
         cy.wait(100).then(() => {
           expect(getLayers(map)).to.deep.eq([
-            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-tracks-1-A', visible: false },
             { title: 'device-wearer-labels-1', visible: false },
             { title: 'device-wearer-circles-1', visible: false },
             { title: 'device-wearer-positions-1', visible: false },
-            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-tracks-2-A', visible: false },
             { title: 'device-wearer-labels-2', visible: true },
             { title: 'device-wearer-circles-2', visible: true },
             { title: 'device-wearer-positions-2', visible: true },
@@ -204,11 +236,11 @@ context('Crime Version', () => {
         // Then the device wearer 2 layers should be hidden
         cy.wait(100).then(() => {
           expect(getLayers(map)).to.deep.eq([
-            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-tracks-1-A', visible: false },
             { title: 'device-wearer-labels-1', visible: true },
             { title: 'device-wearer-circles-1', visible: true },
             { title: 'device-wearer-positions-1', visible: true },
-            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-tracks-2-A', visible: false },
             { title: 'device-wearer-labels-2', visible: false },
             { title: 'device-wearer-circles-2', visible: false },
             { title: 'device-wearer-positions-2', visible: false },
@@ -231,11 +263,11 @@ context('Crime Version', () => {
         // Then the device wearer 1 tracks should be shown
         cy.wait(100).then(() => {
           expect(getLayers(map)).to.deep.eq([
-            { title: 'device-wearer-tracks-1', visible: true },
+            { title: 'device-wearer-tracks-1-A', visible: true },
             { title: 'device-wearer-labels-1', visible: true },
             { title: 'device-wearer-circles-1', visible: true },
             { title: 'device-wearer-positions-1', visible: true },
-            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-tracks-2-A', visible: false },
             { title: 'device-wearer-labels-2', visible: true },
             { title: 'device-wearer-circles-2', visible: true },
             { title: 'device-wearer-positions-2', visible: true },
@@ -258,11 +290,11 @@ context('Crime Version', () => {
         // Then the device wearer 1 tracks should be shown
         cy.wait(100).then(() => {
           expect(getLayers(map)).to.deep.eq([
-            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-tracks-1-A', visible: false },
             { title: 'device-wearer-labels-1', visible: true },
             { title: 'device-wearer-circles-1', visible: true },
             { title: 'device-wearer-positions-1', visible: true },
-            { title: 'device-wearer-tracks-2', visible: true },
+            { title: 'device-wearer-tracks-2-A', visible: true },
             { title: 'device-wearer-labels-2', visible: true },
             { title: 'device-wearer-circles-2', visible: true },
             { title: 'device-wearer-positions-2', visible: true },
@@ -294,11 +326,11 @@ context('Crime Version', () => {
         // Then the device wearer 2 circle layer should remain hidden
         cy.wait(100).then(() => {
           expect(getLayers(map)).to.deep.eq([
-            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-tracks-1-A', visible: false },
             { title: 'device-wearer-labels-1', visible: true },
             { title: 'device-wearer-circles-1', visible: true },
             { title: 'device-wearer-positions-1', visible: true },
-            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-tracks-2-A', visible: false },
             { title: 'device-wearer-labels-2', visible: false },
             { title: 'device-wearer-circles-2', visible: false },
             { title: 'device-wearer-positions-2', visible: false },
@@ -330,11 +362,11 @@ context('Crime Version', () => {
         // Then the device wearer 2 circle layer should remain hidden
         cy.wait(100).then(() => {
           expect(getLayers(map)).to.deep.eq([
-            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-tracks-1-A', visible: false },
             { title: 'device-wearer-labels-1', visible: true },
             { title: 'device-wearer-circles-1', visible: true },
             { title: 'device-wearer-positions-1', visible: true },
-            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-tracks-2-A', visible: false },
             { title: 'device-wearer-labels-2', visible: false },
             { title: 'device-wearer-circles-2', visible: false },
             { title: 'device-wearer-positions-2', visible: false },
@@ -361,11 +393,11 @@ context('Crime Version', () => {
         // And the device wearer layers should be hidden
         cy.wait(100).then(() => {
           expect(getLayers(map)).to.deep.eq([
-            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-tracks-1-A', visible: false },
             { title: 'device-wearer-labels-1', visible: false },
             { title: 'device-wearer-circles-1', visible: false },
             { title: 'device-wearer-positions-1', visible: false },
-            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-tracks-2-A', visible: false },
             { title: 'device-wearer-labels-2', visible: false },
             { title: 'device-wearer-circles-2', visible: false },
             { title: 'device-wearer-positions-2', visible: false },
@@ -382,11 +414,11 @@ context('Crime Version', () => {
         // And the device wearer layers should be shown
         cy.wait(100).then(() => {
           expect(getLayers(map)).to.deep.eq([
-            { title: 'device-wearer-tracks-1', visible: false },
+            { title: 'device-wearer-tracks-1-A', visible: false },
             { title: 'device-wearer-labels-1', visible: true },
             { title: 'device-wearer-circles-1', visible: true },
             { title: 'device-wearer-positions-1', visible: true },
-            { title: 'device-wearer-tracks-2', visible: false },
+            { title: 'device-wearer-tracks-2-A', visible: false },
             { title: 'device-wearer-labels-2', visible: true },
             { title: 'device-wearer-circles-2', visible: true },
             { title: 'device-wearer-positions-2', visible: true },
@@ -440,7 +472,7 @@ context('Crime Version', () => {
       })
     })
 
-    it.skip('should show the crime overlay', () => {
+    it('should show the crime overlay', () => {
       // When the user loads the page
       cy.visit(`/proximity-alert/${crimeVersionId}`)
 
@@ -473,7 +505,7 @@ context('Crime Version', () => {
       })
     })
 
-    it.skip('should show the device position overlay', () => {
+    it('should show the device position overlay', () => {
       // When the user loads the page
       cy.visit(`/proximity-alert/${crimeVersionId}`)
 

--- a/integration_tests/e2e/proximityAlert/fixtures/index.ts
+++ b/integration_tests/e2e/proximityAlert/fixtures/index.ts
@@ -98,6 +98,41 @@ const crimeVersionWithLatestCrimeVersionId = {
   matching: null,
 }
 
+const crimeVersionWithMultipleSequences = {
+  ...crimeVersion,
+  matching: {
+    deviceWearers: [
+      {
+        ...matchedDeviceWearer1,
+        positions: [
+          {
+            ...matchedDeviceWearer1.positions[0],
+            sequenceLabel: 'A1',
+          },
+          {
+            ...matchedDeviceWearer1.positions[0],
+            latitude: deviceLocation[1] + 0.001,
+            longitude: deviceLocation[0] + 0.001,
+            sequenceLabel: 'A2',
+          },
+          {
+            ...matchedDeviceWearer1.positions[0],
+            latitude: deviceLocation[1] + 0.002,
+            longitude: deviceLocation[0] + 0.002,
+            sequenceLabel: 'B1',
+          },
+          {
+            ...matchedDeviceWearer1.positions[0],
+            latitude: deviceLocation[1] + 0.003,
+            longitude: deviceLocation[0] + 0.003,
+            sequenceLabel: 'B2',
+          },
+        ],
+      },
+    ],
+  },
+}
+
 export {
   crimeLocation,
   crimeVersionAwaitingMatching,
@@ -108,4 +143,5 @@ export {
   crimeVersionId,
   deviceLocation,
   hubManager,
+  crimeVersionWithMultipleSequences,
 }

--- a/integration_tests/e2e/proximityAlert/fixtures/index.ts
+++ b/integration_tests/e2e/proximityAlert/fixtures/index.ts
@@ -117,14 +117,14 @@ const crimeVersionWithMultipleSequences = {
           },
           {
             ...matchedDeviceWearer1.positions[0],
-            latitude: deviceLocation[1] + 0.002,
-            longitude: deviceLocation[0] + 0.002,
+            latitude: deviceLocation[1],
+            longitude: deviceLocation[0] - 0.001,
             sequenceLabel: 'B1',
           },
           {
             ...matchedDeviceWearer1.positions[0],
-            latitude: deviceLocation[1] + 0.003,
-            longitude: deviceLocation[0] + 0.003,
+            latitude: deviceLocation[1] - 0.001,
+            longitude: deviceLocation[0] + 0.001,
             sequenceLabel: 'B2',
           },
         ],


### PR DESCRIPTION
Add a separate Tracks Layer for each sequence (e.g. A1, A2 and B1, B2, etc.) rather than just one Tracks layer per device wearer.

[https://dsdmoj.atlassian.net/browse/ACR-918](https://dsdmoj.atlassian.net/browse/ACR-918)