### PR TITLE
ACR-479 Create Hub Manager audit update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Description
+<!-- Clearly describe what this PR does -->
+
+## Related JIRA tickets
+<!-- Link relevant issues -->
+
+## Checklist
+<!-- Mark with an 'x' when done -->
+- [ ] Audit event logging added if relevant
+- [ ] Integration tests created if relevant
+- [ ] Tests passing
+- [ ] Lint check passing
+
+## Screenshots
+<!-- Provide visuals for UI updates if applicable -->
+
+## How to Test
+<!-- Step-by-step instructions -->
+
+## Dependencies
+<!-- List any new dependencies -->
+- Added:
+- Removed:
+- Updated:
+
+### Additional Changes
+---
+<!-- List any additional updates or fixes  -->

--- a/integration_tests/e2e/hubManager/create.page.cy.ts
+++ b/integration_tests/e2e/hubManager/create.page.cy.ts
@@ -88,17 +88,13 @@ context('Create Hub Manager', () => {
           who: 'USER1',
           what: 'CREATE_ATTEMPT_HUB_MANAGER',
           service: 'hmpps-electronic-monitoring-crime-matching-ui',
-          details: {
-            name: 'Test manager',
-          },
+          details: '{"name":"Test manager","filename":"signature.png"}',
         },
         {
           who: 'USER1',
           what: 'CREATE_SUCCESS_HUB_MANAGER',
           service: 'hmpps-electronic-monitoring-crime-matching-ui',
-          details: {
-            name: 'Test manager',
-          },
+          details: '{"name":"Test manager","filename":"signature.png"}',
         },
       ])
     })

--- a/integration_tests/e2e/hubManager/create.page.cy.ts
+++ b/integration_tests/e2e/hubManager/create.page.cy.ts
@@ -88,11 +88,17 @@ context('Create Hub Manager', () => {
           who: 'USER1',
           what: 'CREATE_ATTEMPT_HUB_MANAGER',
           service: 'hmpps-electronic-monitoring-crime-matching-ui',
+          details: {
+            name: 'Test manager',
+          },
         },
         {
           who: 'USER1',
           what: 'CREATE_SUCCESS_HUB_MANAGER',
           service: 'hmpps-electronic-monitoring-crime-matching-ui',
+          details: {
+            name: 'Test manager',
+          },
         },
       ])
     })

--- a/server/controllers/hubManagers/create.test.ts
+++ b/server/controllers/hubManagers/create.test.ts
@@ -78,6 +78,7 @@ describe('CreateHubManagerController', () => {
           correlationId: req.id,
           details: {
             name,
+            filename: undefined,
           },
         })
       },
@@ -130,6 +131,7 @@ describe('CreateHubManagerController', () => {
         correlationId: req.id,
         details: {
           name: 'Test manager',
+          filename: 'signature.png',
         },
       })
       expect(auditService.logApiModificationCall).toHaveBeenCalledWith('SUCCESS', 'CREATE', Page.HUB_MANAGER, {
@@ -137,6 +139,7 @@ describe('CreateHubManagerController', () => {
         correlationId: req.id,
         details: {
           name: 'Test manager',
+          filename: 'signature.png',
         },
       })
     })

--- a/server/controllers/hubManagers/create.test.ts
+++ b/server/controllers/hubManagers/create.test.ts
@@ -76,6 +76,9 @@ describe('CreateHubManagerController', () => {
         expect(auditService.logApiModificationCall).toHaveBeenCalledWith('ATTEMPT', 'CREATE', Page.HUB_MANAGER, {
           who: 'fakeUserName',
           correlationId: req.id,
+          details: {
+            name,
+          },
         })
       },
     )
@@ -125,10 +128,16 @@ describe('CreateHubManagerController', () => {
       expect(auditService.logApiModificationCall).toHaveBeenCalledWith('ATTEMPT', 'CREATE', Page.HUB_MANAGER, {
         who: 'fakeUserName',
         correlationId: req.id,
+        details: {
+          name: 'Test manager',
+        },
       })
       expect(auditService.logApiModificationCall).toHaveBeenCalledWith('SUCCESS', 'CREATE', Page.HUB_MANAGER, {
         who: 'fakeUserName',
         correlationId: req.id,
+        details: {
+          name: 'Test manager',
+        },
       })
     })
   })

--- a/server/controllers/hubManagers/create.ts
+++ b/server/controllers/hubManagers/create.ts
@@ -17,17 +17,25 @@ export default class CreateHubManagersController {
     const { username } = res.locals.user
     const { name } = req.body
     const { file } = req
-    const result = await this.hubManagersService.createHubManager(username, name, file)
 
+    // TODO include filename as well?
     await this.auditService.logApiModificationCall('ATTEMPT', 'CREATE', Page.HUB_MANAGER, {
       who: res.locals.user.username,
       correlationId: req.id,
+      details: {
+        name,
+      },
     })
+
+    const result = await this.hubManagersService.createHubManager(username, name, file)
 
     if (result.ok) {
       await this.auditService.logApiModificationCall('SUCCESS', 'CREATE', Page.HUB_MANAGER, {
         who: res.locals.user.username,
         correlationId: req.id,
+        details: {
+          name,
+        },
       })
       res.redirect(303, URLS.HUB_MANAGERS.VIEW)
     } else {

--- a/server/controllers/hubManagers/create.ts
+++ b/server/controllers/hubManagers/create.ts
@@ -18,12 +18,12 @@ export default class CreateHubManagersController {
     const { name } = req.body
     const { file } = req
 
-    // TODO include filename as well?
     await this.auditService.logApiModificationCall('ATTEMPT', 'CREATE', Page.HUB_MANAGER, {
       who: res.locals.user.username,
       correlationId: req.id,
       details: {
         name,
+        filename: file?.originalname,
       },
     })
 
@@ -35,6 +35,7 @@ export default class CreateHubManagersController {
         correlationId: req.id,
         details: {
           name,
+          filename: file?.originalname,
         },
       })
       res.redirect(303, URLS.HUB_MANAGERS.VIEW)


### PR DESCRIPTION
Testing revealed some missing context when auditing the create hub manager functionality, this PR adds the context and corrects the order in which the events are logged.