### PR TITLE
ACR-920: Provide attribution for OS maps.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ministryofjustice/frontend": "^10.0.1",
         "@ministryofjustice/hmpps-auth-clients": "3.0.0",
         "@ministryofjustice/hmpps-azure-telemetry": "1.0.2",
-        "@ministryofjustice/hmpps-electronic-monitoring-components": "0.2.20",
+        "@ministryofjustice/hmpps-electronic-monitoring-components": "0.3.0",
         "@ministryofjustice/hmpps-monitoring": "2.1.0",
         "@ministryofjustice/hmpps-probation-frontend-components": "^1.0.2",
         "@ministryofjustice/hmpps-rest-client": "2.2.0",
@@ -2596,11 +2596,12 @@
       }
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.3.tgz",
+      "integrity": "sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 22"
       }
     },
     "node_modules/@mapbox/point-geometry": {
@@ -2622,14 +2623,26 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
-      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
+      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "~1.1.0",
         "@types/geojson": "^7946.0.16",
-        "pbf": "^4.0.1"
+        "pbf": "^4.0.2"
+      }
+    },
+    "node_modules/@mapbox/vector-tile/node_modules/pbf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/@mapbox/whoots-js": {
@@ -2642,22 +2655,22 @@
       }
     },
     "node_modules/@maplibre/geojson-vt": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
-      "integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
+      "integrity": "sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==",
       "license": "ISC",
       "dependencies": {
-        "kdbush": "^4.0.2"
+        "kdbush": "^4.1.0"
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "24.8.5",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.5.tgz",
-      "integrity": "sha512-EzEJmMt6thioRH7GI9LWS7ahXTcAhAPGWCe6oTP2Ps4YnsXOOAfeqx854lZaiDnwURfHmcCKV1mr6oo0i23x6w==",
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.10.0.tgz",
+      "integrity": "sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/unitbezier": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
         "quickselect": "^3.0.0",
@@ -2669,35 +2682,43 @@
         "gl-style-validate": "dist/gl-style-validate.mjs"
       }
     },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@maplibre/mlt": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.9.tgz",
-      "integrity": "sha512-g/tD8EYJB97udq33ipuJ9a4Q7fcbZnTEnUrgnEc/tLMmEL+zaCbR+X5fkDBO2dgpaAMsLH179qE3UXg2N0Nc/g==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.12.tgz",
+      "integrity": "sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0"
       }
     },
     "node_modules/@maplibre/vt-pbf": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
-      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.2.tgz",
+      "integrity": "sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==",
       "license": "MIT",
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@maplibre/geojson-vt": "^5.0.4",
         "@types/geojson": "^7946.0.16",
-        "@types/supercluster": "^7.1.3",
-        "pbf": "^4.0.1",
-        "supercluster": "^8.0.1"
+        "pbf": "^5.1.0"
       }
     },
-    "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
-      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
-      "license": "ISC"
+    "node_modules/@maplibre/vt-pbf/node_modules/pbf": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
     },
     "node_modules/@ministryofjustice/eslint-config-hmpps": {
       "version": "1.0.3",
@@ -2776,9 +2797,9 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-electronic-monitoring-components": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-electronic-monitoring-components/-/hmpps-electronic-monitoring-components-0.2.20.tgz",
-      "integrity": "sha512-FeCbsF3vO0vLhDjzciSJhXo/u94zb21UwQ9Rln9+IdSBoceFM8GxIBXJp6IZyqZg1qe2ceuFMuPSWYT+FuQ/gQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-electronic-monitoring-components/-/hmpps-electronic-monitoring-components-0.3.0.tgz",
+      "integrity": "sha512-SB63qNvgVrdAMvlHbdMX0AjBQ8xgy2fJECoWBMZ1E0d3pZ1T5CKNJfXzPP5sEqb0lUP52FXCs7I6H+NE/t9uAQ==",
       "license": "MIT",
       "dependencies": {
         "@types/qs": "^6.9.18",
@@ -4933,15 +4954,6 @@
         "@types/methods": "^1.1.4",
         "@types/node": "*",
         "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@types/supercluster": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
-      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
       }
     },
     "node_modules/@types/supertest": {
@@ -11774,9 +11786,9 @@
       }
     },
     "node_modules/kdbush": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
       "license": "ISC"
     },
     "node_modules/keyv": {
@@ -13130,9 +13142,9 @@
       }
     },
     "node_modules/ol-mapbox-style": {
-      "version": "13.4.1",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-13.4.1.tgz",
-      "integrity": "sha512-da4FKZUXoXMzK5ADeRHAXzd3bTeiKg/Y9LBOTB6qNTP62MQm93y6ISrIXzOS9atfGgQMEHJ2pCgP272IMeZCXA==",
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-13.4.2.tgz",
+      "integrity": "sha512-UJNNr8rEfLGullGHfdfxwpoisLAteHJ+WdSmT4VewDn5BgTkTJX1zGGQ997NYGTJxJpbW44Q9rKo8BJOKIB2Lg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^24.4.1",
@@ -15411,15 +15423,6 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/supercluster": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
-      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^4.0.2"
       }
     },
     "node_modules/supertest": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@ministryofjustice/frontend": "^10.0.1",
     "@ministryofjustice/hmpps-auth-clients": "3.0.0",
     "@ministryofjustice/hmpps-azure-telemetry": "1.0.2",
-    "@ministryofjustice/hmpps-electronic-monitoring-components": "0.2.20",
+    "@ministryofjustice/hmpps-electronic-monitoring-components": "0.3.0",
     "@ministryofjustice/hmpps-monitoring": "2.1.0",
     "@ministryofjustice/hmpps-probation-frontend-components": "^1.0.2",
     "@ministryofjustice/hmpps-rest-client": "2.2.0",

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -45,4 +45,5 @@ export default function nunjucksSetup(app: express.Express): void {
   njkEnv.addFilter('assetMap', (url: string) => assetManifest[url] || url)
   njkEnv.addFilter('formatDateTime', formatDateTime)
   njkEnv.addGlobal('pagination', pagination)
+  njkEnv.addGlobal('currentYear', () => new Date().getFullYear())
 }

--- a/server/views/components/map/template.njk
+++ b/server/views/components/map/template.njk
@@ -12,6 +12,8 @@
           cspNonce: params.cspNonce,
           positions: params.positions,
           usesInternalOverlays: params.usesInternalOverlays,
+          attribution: 'Contains OS data © Crown copyright and database rights ' + currentYear() + '. OS AC0000850671',
+          attributionAllowHtml: true,
           controls: {
             scaleControl: 'bar',
             locationDisplay: 'dms',

--- a/server/views/pages/legal/index.njk
+++ b/server/views/pages/legal/index.njk
@@ -6,4 +6,16 @@
 
 {% block content %}
   <h1>Legal</h1>
+
+  <h2 class="govuk-heading-l">Ordnance Survey data</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">
+        Contains OS data © Crown copyright and database rights {{ currentYear() }} OS AC0000850671. You are permitted to
+        use this data solely to enable you to respond to, or interact with, the organisation that provided you with the
+        data. You are not permitted to copy, sub-license, distribute or sell any of this data to third parties in any
+        form.
+      </p>
+    </div>
+  </div>
 {% endblock %}


### PR DESCRIPTION
TODO bump to version 0.4.0 when https://github.com/ministryofjustice/hmpps-electronic-monitoring-components/pull/109/changes is merged

## Description

- Adds attribution to the OS maps we provide.
- Adds additional terms and conditions to the Legal section.

## Related JIRA tickets
ACR-920

## Checklist
- [ N/A] Audit event logging added if relevant
- [N/A ] Integration tests created if relevant

## Screenshots
<img width="1329" height="816" alt="image" src="https://github.com/user-attachments/assets/ad578dd1-9bdb-4123-a171-f27a2cfc4930" />
<img width="599" height="409" alt="image" src="https://github.com/user-attachments/assets/bab3ba41-2134-46b8-9a97-167feb33e555" />
<img width="1329" height="816" alt="image" src="https://github.com/user-attachments/assets/68da0661-e5f8-4125-8cc6-ba6a8d20b227" />




## How to Test
View a Proximity Alert map.

## Dependencies
- Added: None
- Removed: None
- Updated: @ministryofjustice/hmpps-electronic-monitoring-components 0.2.2 -> 0.3.0

### Additional Changes
N/A