### PR TITLE
Fix Helm Deploy concurrent collision

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -22,12 +22,8 @@ permissions:
   packages: write
 
 concurrency:
-  # Only cancel in progress when on a branch - use SHA on main to ensure uniqueness.
-  # This will allow multiple pipelines to run at the same time on main.
-  # Note that two pipelines running within a few minutes of each other will cause issues with helm deploying to
-  # a namespace, as the second one will not be able to get a lock as a deploy will be in progress.
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false  # queue rather than cancel, to allow merges in quick succession
 
 jobs:
   # main node build workflow


### PR DESCRIPTION
## Description
To prevent this issue when deploying two changes to an environment in parallel

```
Run yq -i ".appVersion = \"2026-07-31.1351.1216d28\"" "helm_deploy/hmpps-electronic-monitoring-crime-matching-ui/Chart.yaml"
  Getting updates for unmanaged Helm repositories...
  ...Successfully got an update from the "https://ministryofjustice.github.io/hmpps-helm-charts" chart repository
  Saving 2 charts
  Downloading generic-service from repo https://ministryofjustice.github.io/hmpps-helm-charts
  Downloading generic-prometheus-alerts from repo https://ministryofjustice.github.io/hmpps-helm-charts
  Deleting outdated charts
  Error: UPGRADE FAILED: release: already exists
  Error: Process completed with exit code 1.
```

## Related JIRA tickets
N/A

## Checklist
<!-- Mark with an 'x' when done -->
- [ N/A] Audit event logging added if relevant
- [ N/A] Integration tests created if relevant

## Screenshots
N/A

## How to Test
Merge two branches into dev at once! 

## Dependencies
N/A
- Added:
- Removed:
- Updated:

### Additional Changes
N/A