### PR TITLE
Sync typescript template

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ node_modules
 npm-debug.log
 .*
 !.allowed-scripts.mjs
+!.npmrc
 **/*.test.js
 scss-report.txt
 eslint-report.html

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,83 @@
+# Copilot instructions for hmpps-electronic-monitoring-crime-matching-ui
+
+These notes capture architectural decisions specific to this service so that
+future Copilot-assisted changes don't drift back to older HMPPS patterns.
+This is not a claim that the service is fully aligned with the latest
+`hmpps-template-typescript` - check current template state before assuming so.
+
+## Outbound HTTP clients
+
+- All calls to the Crime Matching API go through `server/data/crimeMatchingClient.ts`,
+  which extends `RestClient` from `@ministryofjustice/hmpps-rest-client`. Add new
+  endpoints as methods on this class using the methods exposed by `RestClient`,
+  not by constructing `superagent` requests or `http(s).Agent` instances
+  directly.
+- Do not use `superagent` directly for outbound application requests. Existing
+  imports used only for error types should remain type-only imports.
+- `agentkeepalive` currently satisfies `@ministryofjustice/hmpps-monitoring`'s
+  peer dependency as well as being used internally by `hmpps-rest-client`. Run
+  `npm explain agentkeepalive` before removing or downgrading it to confirm
+  nothing still requires it.
+- `server/config.ts` imports `AgentConfig` from `@ministryofjustice/hmpps-rest-client`
+  rather than declaring its own. When adding a new `apis.*` entry, reuse
+  `new AgentConfig(timeoutMs)` for the `agent` field - don't reintroduce a local
+  agent config type.
+- Proxy configuration (`NODE_USE_ENV_PROXY`, `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`)
+  must never be added to Helm values referencing a namespace secret
+  (e.g. `hmpps-envoy-https-proxy-env`) until that secret has actually been
+  provisioned in the target Cloud Platform namespace. Referencing an
+  unprovisioned secret will fail deployment - verify provisioning first.
+
+## Auth
+
+- Token acquisition, verification and storage go through
+  `@ministryofjustice/hmpps-auth-clients` (`AuthenticationClient`,
+  `VerificationClient`, `InMemoryTokenStore`/`RedisTokenStore` - see
+  `server/data/index.ts` and `server/middleware/setUpAuthentication.ts`). Do not
+  hand-roll a token store, token verification call, or OAuth token exchange -
+  extend the existing wiring instead.
+- Authenticated calls to the Crime Matching API must pass an explicit
+  `AuthOptions` via `asSystem(username)` or `asUser(...)` from
+  `@ministryofjustice/hmpps-rest-client` (see `server/services/*Service.ts`).
+- `config.apis.hmppsAuth` uses `authClientId`/`authClientSecret`/`systemClientId`/
+  `systemClientSecret` - these are the current field names expected by
+  `hmpps-auth-clients`. Do not reintroduce older names like `apiClientId`.
+- The current user's identity (`username`, `userId`, `authSource`, roles, etc.)
+  comes from the JWT via `HmppsUser`/`BaseUser` in
+  `server/interfaces/hmppsUser.ts`, populated in `setUpAuthentication.ts`. There
+  is no separate "get current user" API client in this repo - before adding one
+  to fetch user display data, check whether it's already available on
+  `req.user`/`res.locals.user`.
+
+## Config
+
+- `config.ingressUrl` (not `domain`) is the canonical base URL for this service,
+  used for OAuth callback/redirect construction in `setUpAuthentication.ts`.
+- Every entry under `config.apis` should have `url`, `healthPath`, `timeout:
+  {response, deadline}` and `agent: new AgentConfig(...)` so it can be passed to
+  both a `RestClient` subclass and `endpointHealthComponent` in
+  `setUpHealthChecks.ts` - `probationApi` is the one exception (health-check only,
+  no outbound `RestClient` calls), so don't treat it as the template for a new
+  entry that needs a REST client.
+
+## Redis
+
+- `server/data/redisClient.ts`'s `createRedisClient()` is shared between the
+  Express session store (`connect-redis`) and `RedisTokenStore`. If you change
+  Redis connection options, both consumers are affected.
+
+## Health checks / monitoring / telemetry
+
+- Health checks are wired through `@ministryofjustice/hmpps-monitoring`
+  (`endpointHealthComponent`, `monitoringMiddleware` in
+  `server/middleware/setUpHealthChecks.ts`), derived automatically from
+  `Object.entries(config.apis)`. Adding a new `config.apis.*` entry with a
+  `healthPath` is enough to get it health-checked - don't write a bespoke health
+  check route.
+- Telemetry (`server/utils/azureAppInsights.ts`) is initialised via
+  `@ministryofjustice/hmpps-azure-telemetry` and is imported in `server.ts`
+  **before** `logger`. Preserve this ordering because telemetry must be
+  initialised before modules that create or use the logger.
+
+For ongoing template maintenance, use the `sync-typescript-template` skill
+rather than re-deriving these patterns from scratch.

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -65,7 +65,6 @@ jobs:
     secrets: inherit
   build:
     name: Build docker image from hmpps-github-actions
-    if: github.ref == 'refs/heads/main'
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
     needs:
       - node_integration_tests
@@ -74,10 +73,11 @@ jobs:
       docker_registry: 'ghcr.io'
       registry_org: 'ministryofjustice'
       additional_docker_tag: ${{ inputs.additional_docker_tag }}
-      push: ${{ inputs.push || inputs.push == null }}
+      push: ${{ github.ref == 'refs/heads/main' && (inputs.push || inputs.push == null) }}
       docker_multiplatform: false
   deploy_dev:
     name: Deploy to the development environment
+    if: github.ref == 'refs/heads/main'
     needs:
       - build
       - helm_lint

--- a/.github/workflows/security_codeql_scan.yml
+++ b/.github/workflows/security_codeql_scan.yml
@@ -1,0 +1,19 @@
+name: Security CodeQL javascript/typescript scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "19 6 * * MON-FRI" # Every weekday
+
+jobs:
+  security-codeql-check:
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    name: Project security CodeQL javascript/typescript scan
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_codeql.yml@v2 # WORKFLOW_VERSION
+    with:
+      channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
+      languages: javascript-typescript
+    secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 
 repos:
   - repo: https://github.com/ministryofjustice/devsecops-hooks
-    rev: v1.4.1
+    rev: v2.0.2
     hooks:
       - id: baseline
         env:
@@ -18,21 +18,21 @@ repos:
         name: linting code
         language: system
         entry: ./node_modules/.bin/lint-staged
-        types_or: [ts,javascript,css]
+        files: (\.(ts|js|css)$|^package-lock\.json$)
         require_serial: true
         pass_filenames: false
       - id: typecheck
         name: verify types
         language: system
         entry: npm run typecheck
-        types: [ts]
+        files: (\.(ts)$|^package-lock\.json$)
         require_serial: true
         pass_filenames: false
       - id: test
         name: running tests
         language: system
         entry: npm run test
-        types: [ts]
+        files: (\.(ts)$|^package-lock\.json$)
         require_serial: true
         pass_filenames: false
   - repo: builtin

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ARG BUILD_NUMBER
 ARG GIT_REF
 ARG GIT_BRANCH
 
-COPY package*.json .allowed-scripts.mjs ./
+COPY package*.json .allowed-scripts.mjs .npmrc ./
 RUN NPM_CONFIG_AUDIT=false NPM_CONFIG_FUND=false npm run setup
 ENV NODE_ENV='production'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@types/qs": "^6.15.0",
         "agentkeepalive": "^4.6.0",
         "axios": "1.18.1",
-        "body-parser": "^2.2.2",
         "bunyan": "^1.8.15",
         "bunyan-format": "^0.2.1",
         "compression": "^1.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.1019.0",
         "@ministryofjustice/frontend": "^10.0.1",
-        "@ministryofjustice/hmpps-auth-clients": "1.0.2",
+        "@ministryofjustice/hmpps-auth-clients": "3.0.0",
         "@ministryofjustice/hmpps-azure-telemetry": "1.0.2",
         "@ministryofjustice/hmpps-electronic-monitoring-components": "0.2.20",
         "@ministryofjustice/hmpps-monitoring": "2.1.0",
@@ -46,7 +46,7 @@
         "passport": "^0.7.0",
         "passport-oauth2": "^1.8.0",
         "playwright": "1.60.0",
-        "redis": "^5.11.0",
+        "redis": "6.0.0",
         "superagent": "^10.3.0",
         "zod": "^4.3.6"
       },
@@ -2729,26 +2729,15 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-auth-clients": {
-      "version": "1.0.2",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-auth-clients/-/hmpps-auth-clients-3.0.0.tgz",
+      "integrity": "sha512-XVo53jR3VBLTXgoOpRiwKIDT3bD8u/JB/kxlsVrxOWqkZ1L+/zt4CQIUOnG6e28CdhhJhGd0kKFRW/F8Mil1ow==",
       "license": "MIT",
       "dependencies": {
-        "@ministryofjustice/hmpps-rest-client": "^1.0.1"
+        "@ministryofjustice/hmpps-rest-client": "^1.2.1 || ^2.0.0"
       },
       "engines": {
-        "node": "20 || 22 || 24"
-      }
-    },
-    "node_modules/@ministryofjustice/hmpps-auth-clients/node_modules/@ministryofjustice/hmpps-rest-client": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-rest-client/-/hmpps-rest-client-1.2.1.tgz",
-      "integrity": "sha512-lioBIPZr9+hv+Gc+u/BSsuwPxmd2jEYeN1k5THiPogM14OmEB7yQjFD7WNSbJfkr+M4njvAUbgRvUTQgQI8oGg==",
-      "license": "MIT",
-      "dependencies": {
-        "agentkeepalive": "^4.6.0",
-        "superagent": "^10.3.0"
-      },
-      "engines": {
-        "node": "20 || 22 || 24"
+        "node": "22 || 24 || 26"
       }
     },
     "node_modules/@ministryofjustice/hmpps-azure-telemetry": {
@@ -3938,6 +3927,78 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-6.0.0.tgz",
+      "integrity": "sha512-P0n5NkV9IIdT6nYXOfMHG83sho8pE7Nay7yw27wOGVLv4DthgvzebpGz6m7VuMTizeJmw3LPw2Xek5wFUhGpVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.0.0.tgz",
+      "integrity": "sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-6.0.0.tgz",
+      "integrity": "sha512-F+eqFfgPcy57Zs1KW7UtLnBtRk6lxAUIoe7dyZerpm6e+ssYXG/dWJrbrHFYs0b7tt6QBtYpVuukBuM9XqhUAg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-6.0.0.tgz",
+      "integrity": "sha512-VHuCJ2W0YWFixGZh/l//8JiyOsD4gN+NhjdRAGIoUe0UQ4mtq1NyY2ZJ973XT+vYhaU21XdK8r8oNrd5n7wbzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-6.0.0.tgz",
+      "integrity": "sha512-QWhkYsg+3lhBrBf+cbzybtV8LQcSrk7iXIgTaGU+pHNFTkql7TpVRE24ROS6M2ybVIV6O/zxTqfxgxxYiqyw0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.0.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -6715,6 +6776,8 @@
     },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
@@ -9163,7 +9226,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14061,75 +14123,19 @@
       }
     },
     "node_modules/redis": {
-      "version": "5.11.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-6.0.0.tgz",
+      "integrity": "sha512-n9Thfc39OXleEoPT2k5gwKsqY+HfCww3YS71ofcr9KKbkn89bpjU9dToIlD+JRdM3/GYQkwMtVgTxLyed+LptQ==",
       "license": "MIT",
       "dependencies": {
-        "@redis/bloom": "5.11.0",
-        "@redis/client": "5.11.0",
-        "@redis/json": "5.11.0",
-        "@redis/search": "5.11.0",
-        "@redis/time-series": "5.11.0"
+        "@redis/bloom": "6.0.0",
+        "@redis/client": "6.0.0",
+        "@redis/json": "6.0.0",
+        "@redis/search": "6.0.0",
+        "@redis/time-series": "6.0.0"
       },
       "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/redis/node_modules/@redis/bloom": {
-      "version": "5.11.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@redis/client": "^5.11.0"
-      }
-    },
-    "node_modules/redis/node_modules/@redis/client": {
-      "version": "5.11.0",
-      "license": "MIT",
-      "dependencies": {
-        "cluster-key-slot": "1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@node-rs/xxhash": "^1.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@node-rs/xxhash": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/redis/node_modules/@redis/json": {
-      "version": "5.11.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@redis/client": "^5.11.0"
-      }
-    },
-    "node_modules/redis/node_modules/@redis/search": {
-      "version": "5.11.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@redis/client": "^5.11.0"
-      }
-    },
-    "node_modules/redis/node_modules/@redis/time-series": {
-      "version": "5.11.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@redis/client": "^5.11.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/reference-spec-reader": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@types/qs": "^6.15.0",
     "agentkeepalive": "^4.6.0",
     "axios": "1.18.1",
-    "body-parser": "^2.2.2",
     "bunyan": "^1.8.15",
     "bunyan-format": "^0.2.1",
     "compression": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.1019.0",
     "@ministryofjustice/frontend": "^10.0.1",
-    "@ministryofjustice/hmpps-auth-clients": "1.0.2",
+    "@ministryofjustice/hmpps-auth-clients": "3.0.0",
     "@ministryofjustice/hmpps-azure-telemetry": "1.0.2",
     "@ministryofjustice/hmpps-electronic-monitoring-components": "0.2.20",
     "@ministryofjustice/hmpps-monitoring": "2.1.0",
@@ -67,7 +67,7 @@
     "passport": "^0.7.0",
     "passport-oauth2": "^1.8.0",
     "playwright": "1.60.0",
-    "redis": "^5.11.0",
+    "redis": "6.0.0",
     "superagent": "^10.3.0",
     "zod": "^4.3.6"
   },

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -6,7 +6,6 @@ import type { ExportProximityAlertState } from '../form-pages/proximityAlert/exp
 export declare module 'express-session' {
   interface SessionData {
     returnTo: string
-    nowInMinutes: number
     formData: unknown
     validationErrors: ValidationResult
     exportProximityAlertState?: ExportProximityAlertState

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,3 +1,5 @@
+import { AgentConfig } from '@ministryofjustice/hmpps-rest-client'
+
 const production = process.env.NODE_ENV === 'production'
 
 function get<T>(name: string, fallback: T, options = { requireInProduction: false }): T | string {
@@ -11,28 +13,6 @@ function get<T>(name: string, fallback: T, options = { requireInProduction: fals
 }
 
 const requiredInProduction = { requireInProduction: true }
-
-export class AgentConfig {
-  // Sets the working socket to timeout after timeout milliseconds of inactivity on the working socket.
-  timeout: number
-
-  constructor(timeout = 8000) {
-    this.timeout = timeout
-  }
-}
-
-export interface ApiConfig {
-  url: string
-  timeout: {
-    // sets maximum time to wait for the first byte to arrive from the server, but it does not limit how long the
-    // entire download can take.
-    response: number
-    // sets a deadline for the entire request (including all uploads, redirects, server processing time) to complete.
-    // If the response isn't fully downloaded within that time, the request will be aborted.
-    deadline: number
-  }
-  agent: AgentConfig
-}
 
 const auditConfig = () => {
   const auditEnabled = get('AUDIT_ENABLED', 'false') === 'true'

--- a/server/data/redisClient.ts
+++ b/server/data/redisClient.ts
@@ -3,7 +3,9 @@ import { createClient } from 'redis'
 import logger from '../../logger'
 import config from '../config'
 
-export type RedisClient = ReturnType<typeof createClient>
+// Derived from createRedisClient's own return type below, rather than ReturnType<typeof createClient>,
+// because createClient's default RESP version (2) is incompatible with the RESP 3 client constructed here.
+export type RedisClient = ReturnType<typeof createRedisClient>
 
 const url =
   config.redis.tls_enabled === 'true'

--- a/server/data/redisClient.ts
+++ b/server/data/redisClient.ts
@@ -10,8 +10,9 @@ const url =
     ? `rediss://${config.redis.host}:${config.redis.port}`
     : `redis://${config.redis.host}:${config.redis.port}`
 
-export const createRedisClient = (): RedisClient => {
+export const createRedisClient = () => {
   const client = createClient({
+    RESP: 3,
     url,
     password: config.redis.password,
     socket: {

--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -29,13 +29,6 @@ export default function setUpWebSession(): Router {
     }),
   )
 
-  // Update a value in the cookie so that the set-cookie will be sent.
-  // Only changes every minute so that it's not sent with every request.
-  router.use((req, res, next) => {
-    req.session.nowInMinutes = Math.floor(Date.now() / 60e3)
-    next()
-  })
-
   router.use((req, res, next) => {
     const headerName = 'X-Request-Id'
     const oldValue = req.get(headerName)


### PR DESCRIPTION
## Description
Brings the UI closer to the current hmpps-template-typescript baseline using the HMPPS Copilot plugin marketplace.

Two Copilot skills were used:

make-typescript-proxy-aware to assess the application’s HTTP client, authentication, Redis, telemetry and proxy readiness.
sync-typescript-template to identify and apply relevant changes from the current TypeScript template changelog.

### Changes include:

- Upgraded:
  - @ministryofjustice/hmpps-rest-client from 1.2.0 to 2.2.0
  - @ministryofjustice/hmpps-auth-clients from 1.0.2 to 3.0.0
  - redis from 5.11.0 to 6.0.0
- Configured the Redis client to use RESP3, as required by the updated auth client.
- Replaced the locally defined AgentConfig with the implementation exported by hmpps-rest-client.
- Removed the unused direct body-parser dependency.
- Added .npmrc to the Docker build context so npm security settings are applied during image builds.
- Updated pre-commit hook file matching so checks run when package-lock.json changes.
- Updated devsecops-hooks to v2.0.2.
- Added a CodeQL workflow for scanning JavaScript and TypeScript application source.
- Removed the obsolete nowInMinutes session middleware and type.
- Updated the pipeline so feature branches build the Docker image for validation without publishing or deploying it.
- Added repository-specific Copilot instructions covering the established HTTP client, authentication, Redis, telemetry and configuration patterns.

### Deferred follow-up work

The following current-template changes were assessed but are being handled separately due to their wider compatibility or runtime impact:

- Upgrade to TypeScript 6.
- Move the final Docker stage to the hmpps-node:24-alpine-runtime image.
- Consider adopting the newer WireMock helper interface.
- Revisit Envoy egress proxy configuration once the required namespace secret is provisioned and the service-specific requirement is confirmed.

The application now uses a proxy-aware version of hmpps-rest-client, but Helm proxy environment variables have not been added because hmpps-envoy-https-proxy-env is not currently present in the development namespace.

## Related JIRA tickets
[ACR-959](https://dsdmoj.atlassian.net/browse/ACR-959)

## Dependencies
<!-- List any new dependencies -->
- Added: 
  - None
- Removed: 
  - `body-parser` as a direct dependency
- Updated:
  - `@ministryofjustice/hmpps-rest-client: 1.2.0 `-> `2.2.0`
  - `@ministryofjustice/hmpps-auth-clients: 1.0.2` -> `3.0.0`
  - `redis: 5.11.0` -> `6.0.0`

### Additional Changes
---
- Added `.github/copilot-instructions.md` to preserve repository-specific architectural conventions for future Copilot-assisted work.
- Added JavaScript/TypeScript application source scanning alongside the existing GitHub Actions CodeQL scan.
- Confirmed `agentkeepalive` must remain because it is still required by `hmpps-rest-client` and the `hmpps-monitoring` peer dependency.
- Confirmed the existing main-only Docker build condition originated from the original template scaffold and updated it to the current template behaviour.

[ACR-959]: https://dsdmoj.atlassian.net/browse/ACR-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ