### PR TITLE
Use typescript 6

### DIFF
--- a/integration_tests/e2e/policeData/dashboard.export.cy.ts
+++ b/integration_tests/e2e/policeData/dashboard.export.cy.ts
@@ -93,11 +93,12 @@ context('Police Data Dashboard', () => {
       // Then a file should be downloaded
       cy.getDownloads(downloadsFolder)
         .then(files => {
-          const [file] = files
-          return file
+          expect(files, 'downloaded files').to.have.length.greaterThan(0)
+          const [firstFile] = files
+          return firstFile
         })
-        .then(file => {
-          cy.readFile(path.join(downloadsFolder, file)).should('eq', expectedCrimeMatchingResultsCSV)
+        .then(firstFile => {
+          cy.readFile(path.join(downloadsFolder, firstFile)).should('eq', expectedCrimeMatchingResultsCSV)
         })
 
       // And the expected audit message was sent

--- a/integration_tests/e2e/policeData/dashboard.export.cy.ts
+++ b/integration_tests/e2e/policeData/dashboard.export.cy.ts
@@ -92,7 +92,10 @@ context('Police Data Dashboard', () => {
 
       // Then a file should be downloaded
       cy.getDownloads(downloadsFolder)
-        .then(files => files.at(0))
+        .then(files => {
+          const [file] = files
+          return file
+        })
         .then(file => {
           cy.readFile(path.join(downloadsFolder, file)).should('eq', expectedCrimeMatchingResultsCSV)
         })

--- a/integration_tests/e2e/policeData/ingestionAttempt.export.cy.ts
+++ b/integration_tests/e2e/policeData/ingestionAttempt.export.cy.ts
@@ -52,7 +52,10 @@ context('Police Data Ingestion Attempt', () => {
 
       // Then a file should be downloaded
       cy.getDownloads(downloadsFolder)
-        .then(files => files.at(0))
+        .then(files => {
+          const [file] = files
+          return file
+        })
         .then(file => {
           cy.readFile(path.join(downloadsFolder, file)).should(
             'eq',

--- a/integration_tests/e2e/policeData/ingestionAttempt.export.cy.ts
+++ b/integration_tests/e2e/policeData/ingestionAttempt.export.cy.ts
@@ -53,11 +53,12 @@ context('Police Data Ingestion Attempt', () => {
       // Then a file should be downloaded
       cy.getDownloads(downloadsFolder)
         .then(files => {
-          const [file] = files
-          return file
+          expect(files, 'downloaded files').to.have.length.greaterThan(0)
+          const [firstFile] = files
+          return firstFile
         })
-        .then(file => {
-          cy.readFile(path.join(downloadsFolder, file)).should(
+        .then(firstFile => {
+          cy.readFile(path.join(downloadsFolder, firstFile)).should(
             'eq',
             'Crime reference,Error type,Required action\nCR123456,Field must be a valid ENUM value,Amend crime type to a registered crime type\n',
           )

--- a/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
+++ b/integration_tests/e2e/proximityAlert/crimeVersion.page.interactions.cy.ts
@@ -135,7 +135,7 @@ context('Crime Version', () => {
 
         // Then the crime type should be displayed
         expect(textStyles).to.have.length(1)
-        expect(textStyles.at(0)?.at(0)?.getText()?.getText()).to.eq('AB')
+        expect(textStyles[0]?.[0]?.getText()?.getText()).to.eq('AB')
       })
     })
 

--- a/integration_tests/mockApis/crimeMatching/ingestionAttempt.ts
+++ b/integration_tests/mockApis/crimeMatching/ingestionAttempt.ts
@@ -5,7 +5,7 @@ const baseUrl = '/crime-matching'
 
 type StubGetIngestionAttempt200Options = {
   status: 200
-  ingestionAttemptId
+  ingestionAttemptId: string
   response: {
     data: {
       ingestionAttemptId: string
@@ -35,7 +35,7 @@ type StubGetIngestionAttempt200Options = {
 
 type StubGetIngestionAttemptErrorOptions = {
   status: 404 | 500
-  ingestionAttemptId
+  ingestionAttemptId: string
   response: string
 }
 

--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -5,7 +5,7 @@ const url = 'http://localhost:9091/__admin'
 const stubFor = (mapping: Record<string, unknown>): SuperAgentRequest =>
   superagent.post(`${url}/mappings`).send(mapping)
 
-const getMatchingRequests = body => superagent.post(`${url}/requests/find`).send(body)
+const getMatchingRequests = (body: Record<string, unknown>) => superagent.post(`${url}/requests/find`).send(body)
 
 const resetStubs = (): Promise<Array<Response>> =>
   Promise.all([superagent.delete(`${url}/mappings`), superagent.delete(`${url}/requests`)])

--- a/integration_tests/pages/appPage.ts
+++ b/integration_tests/pages/appPage.ts
@@ -4,7 +4,7 @@ import PageHeaderComponent from './components/pageHeaderComponent'
 import NavigationComponent from './components/navigationComponent'
 
 export default class AppPage extends Page {
-  constructor(title: string) {
+  constructor(title: string | null) {
     super(title)
   }
 

--- a/integration_tests/pages/components/forms/exportCrimeMatchingResultsForm.ts
+++ b/integration_tests/pages/components/forms/exportCrimeMatchingResultsForm.ts
@@ -8,7 +8,7 @@ class ExportCrimeMatchingResultsFormComponent extends FormComponent {
 
   // FIELDS
 
-  get exportButton(): PageElement {
+  get exportButton(): PageElement<HTMLButtonElement> {
     return this.form.contains('button', 'Export')
   }
 

--- a/integration_tests/pages/components/forms/exportLocationDataForm.ts
+++ b/integration_tests/pages/components/forms/exportLocationDataForm.ts
@@ -17,7 +17,7 @@ class ExportLocationDataFormComponent extends FormComponent {
     return new FormRadiosComponent(this.form, 'Export trail data')
   }
 
-  get exportButton(): PageElement {
+  get exportButton(): PageElement<HTMLButtonElement> {
     return this.form.contains('button', 'Export')
   }
 

--- a/integration_tests/pages/components/forms/exportValidationErrorsForm.ts
+++ b/integration_tests/pages/components/forms/exportValidationErrorsForm.ts
@@ -8,7 +8,7 @@ class ExportValidationErrorsFormComponent extends FormComponent {
 
   // FIELDS
 
-  get exportButton(): PageElement {
+  get exportButton(): PageElement<HTMLButtonElement> {
     return this.form.contains('button', 'Export')
   }
 

--- a/integration_tests/pages/components/forms/searchCrimeVersionsForm.ts
+++ b/integration_tests/pages/components/forms/searchCrimeVersionsForm.ts
@@ -16,7 +16,7 @@ export default class SearchCrimeVersionsFormComponent extends FormComponent {
     return new FormInputComponent(this.form, 'Crime reference')
   }
 
-  get searchButton(): PageElement {
+  get searchButton(): PageElement<HTMLButtonElement> {
     return this.form.contains('button', 'Search')
   }
 

--- a/integration_tests/pages/components/forms/searchDeviceActivationPositions.ts
+++ b/integration_tests/pages/components/forms/searchDeviceActivationPositions.ts
@@ -22,11 +22,11 @@ export default class SearchDeviceActivationPositionsFormComponent extends FormCo
     return new FormDateTimeComponent(this.form, '#to-date', 'toDate', 'Date to')
   }
 
-  get continueButton(): PageElement {
+  get continueButton(): PageElement<HTMLButtonElement> {
     return this.form.contains('button', 'Apply')
   }
 
-  get resetButton(): PageElement {
+  get resetButton(): PageElement<HTMLButtonElement> {
     return this.form.contains('button', 'Reset')
   }
 

--- a/integration_tests/pages/components/forms/searchIngestionAttemptsForm.ts
+++ b/integration_tests/pages/components/forms/searchIngestionAttemptsForm.ts
@@ -33,7 +33,7 @@ export default class SearchIngestionAttemptsFormComponent extends FormComponent 
     return new FormDateComponent(this.form, 'Date to')
   }
 
-  get searchButton(): PageElement {
+  get searchButton(): PageElement<HTMLButtonElement> {
     return this.form.contains('button', 'Search')
   }
 

--- a/integration_tests/pages/components/forms/searchPersonsForm.ts
+++ b/integration_tests/pages/components/forms/searchPersonsForm.ts
@@ -14,7 +14,7 @@ export default class SearchPersonsFormComponent extends FormComponent {
   }
   // FIELDS
 
-  get searchButton(): PageElement {
+  get searchButton(): PageElement<HTMLButtonElement> {
     return this.form.contains('button', 'Search')
   }
 

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -18,21 +18,26 @@ export default abstract class Page {
 
   signOut = (): PageElement => cy.get('[data-qa=signOut]')
 
-  manageDetails = (): PageElement => {
-    return cy.get('body').then($body => {
+  manageDetails = (): Cypress.Chainable<JQuery<HTMLElement> | null> => {
+    return cy.get('body').then(($body): Cypress.Chainable<JQuery<HTMLElement> | null> => {
       // HMPPS MOJ header pattern
-      if ($body.find('[data-qa=manageDetails]').length) {
-        return cy.get('[data-qa=manageDetails]')
+      const mojLink = $body.find('[data-qa=manageDetails]').first()
+      if (mojLink.length) {
+        return cy.wrap<JQuery<HTMLElement> | null>(mojLink, { log: false })
       }
 
       // Probation Components header pattern
-      if ($body.find('a.probation-common-header__submenu-link').length) {
-        return cy.contains('a.probation-common-header__submenu-link', /account/i)
+      const probationLink = $body
+        .find('a.probation-common-header__submenu-link')
+        .filter((_, el) => /account/i.test(el.textContent ?? ''))
+        .first()
+      if (probationLink.length) {
+        return cy.wrap<JQuery<HTMLElement> | null>(probationLink, { log: false })
       }
 
       // Fallback header (no manage link)
       cy.log('No manage details link found in current header variant')
-      return cy.wrap(null, { log: false })
+      return cy.wrap<JQuery<HTMLElement> | null>(null, { log: false })
     })
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@types/jest": "^29.5.14",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/multer": "2.1.0",
-        "@types/node": "^22.19.15",
+        "@types/node": "^24.13.3",
         "@types/nunjucks": "^3.2.6",
         "@types/passport": "^1.0.17",
         "@types/passport-oauth2": "^1.8.0",
@@ -4828,10 +4828,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/nunjucks": {
@@ -7684,10 +7686,6 @@
       "dependencies": {
         "undici-types": "~7.18.0"
       }
-    },
-    "node_modules/docx/node_modules/undici-types": {
-      "version": "7.18.2",
-      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -16321,7 +16319,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "prettier-plugin-jinja-template": "^2.1.0",
         "supertest": "^7.2.2",
         "ts-jest": "^29.4.6",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.2",
         "uuid": "^14.0.1"
       },
       "engines": {
@@ -16252,7 +16252,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@types/jest": "^29.5.14",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "2.1.0",
-    "@types/node": "^22.19.15",
+    "@types/node": "^24.13.3",
     "@types/nunjucks": "^3.2.6",
     "@types/passport": "^1.0.17",
     "@types/passport-oauth2": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "prettier-plugin-jinja-template": "^2.1.0",
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.6",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "uuid": "^14.0.1"
   },
   "overrides": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "sourceMap": true,
-    "noEmit": false,
+    "noEmit": true,
     "allowJs": false,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
@@ -12,6 +12,7 @@
     "experimentalDecorators": true,
     "typeRoots": ["./server/@types", "./node_modules/@types"],
     "types": ["node", "jest"],
+    "rootDir": ".",
     "strict": true
   },
   "exclude": [


### PR DESCRIPTION
## Description
Upgrades the application from TypeScript 5 to TypeScript 6 and applies the compatibility changes required by the stricter compiler behaviour.

The changes include:

- Upgrading typescript to ^6.0.2
- Aligning @types/node with the application’s Node 24 runtime
- Configuring TypeScript to perform type checking without emitting JavaScript
- Explicitly setting the repository root as the TypeScript source root
- Updating Cypress page helpers so their return types correctly represent elements that may not be present
- Replacing unsupported Array.prototype.at() usage in the integration tests with equivalent optional index access
- Replacing property-style Chai assertions that conflicted with the ESLint no-unused-expressions rule

## Related JIRA tickets
[ACR-959](https://dsdmoj.atlassian.net/browse/ACR-959)

## Checklist
<!-- Mark with an 'x' when done -->
- [ ] Audit event logging added if relevant
- [x] Integration tests created if relevant

Existing integration tests were updated where required for TypeScript 6 compatibility. No new user-facing behaviour was introduced.

## Screenshots
<!-- Provide visuals for UI updates if applicable -->

## How to Test
<!-- Step-by-step instructions -->

## Dependencies
<!-- List any new dependencies -->
- Added: None
- Removed: None
- Updated:
  - typescript: ^5.9.3 → ^6.0.2
  - @types/node: ^22.19.15 → ^24.13.3
  - undici-types: 6.21.0 → 7.18.2

[ACR-959]: https://dsdmoj.atlassian.net/browse/ACR-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ